### PR TITLE
Fix CI tests

### DIFF
--- a/integration-testing/content/notebook/requirements.txt
+++ b/integration-testing/content/notebook/requirements.txt
@@ -1,3 +1,3 @@
-jupyter==1.0.0
-matplotlib>=3.0.3<=3.5.1
-pandas>=0.25.3,<=1.4.1
+jupyter
+matplotlib
+pandas

--- a/vetiver-testing/vetiver-requirements.txt
+++ b/vetiver-testing/vetiver-requirements.txt
@@ -1,6 +1,6 @@
-pandas==1.1.5
-numpy>=1.19.5
-pydantic<2.0.0
+pandas
+numpy
+pydantic
 pytest
 pins
 vetiver


### PR DESCRIPTION
CI was failing due to some pins we didn't need.  This PR just unpins those requirements and is now passing again.
