### PR TITLE
remove RSConnectClient.app_publish(); obsolete workflow (Connect 1.7.6+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Removed
+
+- Uncalled `RSConnectClient.app_publish()` function, which referenced an
+  obsolete workflow.
+
 ## [1.24.0] - 2024-05-28
 
 ### Added

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -336,12 +336,6 @@ class RSConnectClient(HTTPServer):
         response = self._server.handle_bad_response(response)
         return response
 
-    def app_publish(self, app_id: str, access: str):
-        return self.post(
-            "applications/%s" % app_id,
-            body={"access_type": access, "id": app_id, "needs_config": False},
-        )
-
     def app_config(self, app_id: str) -> ConfigureResult:
         response = cast(Union[ConfigureResult, HTTPResponse], self.get("applications/%s/config" % app_id))
         response = self._server.handle_bad_response(response)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title. -->
<!-- Examples: Updates pull request template -->

## Intent

This function is uncalled. Connect removed `needs_config` in 1.7.6.

There are no callers to `app_publish()`.

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
