### PR TITLE
connect: use the public /v1/tasks/{id} endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- The `rsconnect content build run --poll-wait` argument specifies an integral
+  number of seconds. It previously allowed fractional seconds. (#608)
+
+- Uses the public Connect server API endpoint `/v1/tasks/{id}` to poll task
+  progress. (#608)
+
 ### Removed
 
 - Uncalled `RSConnectClient.app_publish()` function, which referenced an

--- a/rsconnect/actions_content.py
+++ b/rsconnect/actions_content.py
@@ -139,7 +139,7 @@ def build_start(
     running: bool = False,
     retry: bool = False,
     all: bool = False,
-    poll_wait: float = 2,
+    poll_wait: int = 1,
     debug: bool = False,
 ):
     build_store = ensure_content_build_store(connect_server)
@@ -302,7 +302,7 @@ def _monitor_build(connect_server: RSConnectServer, content_items: list[ContentI
     return True
 
 
-def _build_content_item(connect_server: RSConnectServer, content: ContentItemWithBuildState, poll_wait: float):
+def _build_content_item(connect_server: RSConnectServer, content: ContentItemWithBuildState, poll_wait: int):
     build_store = ensure_content_build_store(connect_server)
     with RSConnectClient(connect_server) as client:
         # Pending futures will still try to execute when ThreadPoolExecutor.shutdown() is called
@@ -333,7 +333,7 @@ def _build_content_item(connect_server: RSConnectServer, content: ContentItemWit
             def write_log(line: str):
                 log.write("%s\n" % line)
 
-            _, _, task_status = emit_task_log(
+            _, _, task = emit_task_log(
                 connect_server,
                 guid,
                 task_id,
@@ -347,8 +347,8 @@ def _build_content_item(connect_server: RSConnectServer, content: ContentItemWit
         if build_store.aborted():
             return
 
-        build_store.set_content_item_last_build_task_result(guid, task_status)
-        if task_status["code"] != 0:
+        build_store.set_content_item_last_build_task_result(guid, task)
+        if task["code"] != 0:
             logger.error("Build failed: %s" % guid)
             build_store.set_content_item_build_status(guid, BuildStatus.ERROR)
         else:

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -409,6 +409,11 @@ class RSConnectClient(HTTPServer):
                 params["wait"] = wait
         response = cast(Union[TaskStatusV1, HTTPResponse], self.get("v1/tasks/%s" % task_id, query_params=params))
         response = self._server.handle_bad_response(response)
+
+        # compatibility with rsconnect-jupyter
+        response["status"] = response["output"]
+        response["last_status"] = response["last"]
+
         return response
 
     def deploy(

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -2690,9 +2690,9 @@ def get_build_logs(
 @click.option("--all", is_flag=True, help="Build all content, even if it is already marked as COMPLETE.")
 @click.option(
     "--poll-wait",
-    type=click.FloatRange(min=0.5, clamp=True),
-    default=2,
-    help="Defines the number of seconds between polls when polling for build output. Defaults to 2.",
+    type=click.IntRange(min=1, clamp=True),
+    default=1,
+    help="Defines the number of seconds between polls when polling for build output. Defaults to 1.",
 )
 @click.option(
     "--format",
@@ -2720,7 +2720,7 @@ def start_content_build(
     running: bool,
     retry: bool,
     all: bool,
-    poll_wait: float,
+    poll_wait: int,
     format: LogOutputFormat.All,
     debug: bool,
     verbose: int,

--- a/rsconnect/models.py
+++ b/rsconnect/models.py
@@ -552,6 +552,10 @@ class TaskStatusV1(TypedDict):
     last: int
     result: TaskStatusResult | None
 
+    # redundant fields for compatibility with rsconnect-python.
+    last_status: int
+    status: list[str]
+
 
 class BootstrapOutputDTO(TypedDict):
     api_key: str

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -158,6 +158,18 @@ class TestSystemRuntimeCachesAPI(TestCase):
             "error": "",
             "last": 1,
         }
+        expected_task = {
+            "id": "this_is_a_task_id",
+            "user_id": 1,
+            "output": ["Removing runtime cache"],
+            "status": ["Removing runtime cache"],
+            "result": {"type": "", "data": None},
+            "finished": True,
+            "code": 0,
+            "error": "",
+            "last": 1,
+            "last_status": 1,
+        }
         httpretty.register_uri(
             httpretty.GET,
             "http://test-server/__api__/v1/tasks/this_is_a_task_id",
@@ -178,7 +190,8 @@ class TestSystemRuntimeCachesAPI(TestCase):
 
         # Result expectations
         self.assertDictEqual(mocked_delete_output, result)
-        self.assertDictEqual(mocked_task, task)
+        # mocked task plus backwards-compatible fields for rsconnect-jupyter
+        self.assertDictEqual(expected_task, task)
 
     # RSConnectExecutor.delete_runtime_cache() raises the correct error
     @httpretty.activate(verbose=True, allow_net_connect=False)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,24 +31,25 @@ class TestAPI(TestCase):
         self.assertEqual(ce.remote_server.url, connect_server)
 
     def test_output_task_log(self):
-        lines = ["line 1", "line 2", "line 3"]
-        task_status = {
-            "status": lines,
-            "last_status": 3,
-            "finished": True,
+        first_task = {
+            "output": ["line 1", "line 2", "line 3"],
+            "last": 3,
+            "finished": False,
             "code": 0,
         }
         output = []
 
-        self.assertEqual(RSConnectClient.output_task_log(task_status, 0, output.append), 3)
-        self.assertEqual(lines, output)
+        RSConnectClient.output_task_log(first_task, output.append)
+        self.assertEqual(["line 1", "line 2", "line 3"], output)
 
-        task_status["last_status"] = 4
-        task_status["status"] = ["line 4"]
-        self.assertEqual(RSConnectClient.output_task_log(task_status, 3, output.append), 4)
-
-        self.assertEqual(len(output), 4)
-        self.assertEqual(output[3], "line 4")
+        second_task = {
+            "output": ["line 4"],
+            "last": 4,
+            "finished": True,
+            "code": 0,
+        }
+        RSConnectClient.output_task_log(second_task, output.append)
+        self.assertEqual(["line 1", "line 2", "line 3", "line 4"], output)
 
     def test_make_deployment_name(self):
         connect_server = require_connect()
@@ -117,7 +118,7 @@ class TestSystemRuntimeCachesAPI(TestCase):
 
         captured_output = io.StringIO()
         sys.stdout = captured_output
-        ce.delete_runtime_cache(language="Python", version="1.2.3", image_name="teapot", dry_run=True)
+        result, task = ce.delete_runtime_cache(language="Python", version="1.2.3", image_name="teapot", dry_run=True)
         sys.stdout = sys.__stdout__
 
         # Print expectations
@@ -125,7 +126,8 @@ class TestSystemRuntimeCachesAPI(TestCase):
         self.assertEqual(output_lines[0], "Dry run finished")
 
         # Result expectations
-        self.assertDictEqual(mocked_output, ce.result)
+        self.assertDictEqual(mocked_output, result)
+        self.assertEqual(task, None)
 
     # RSConnectExecutor.delete_runtime_cache() wet run returns expected request
     # RSConnectExecutor.delete_runtime_cache() wet run prints expected messages
@@ -146,27 +148,27 @@ class TestSystemRuntimeCachesAPI(TestCase):
             forcing_headers={"Content-Type": "application/json"},
         )
 
-        mocked_task_status = {
+        mocked_task = {
             "id": "this_is_a_task_id",
             "user_id": 1,
-            "status": ["Removing runtime cache"],
+            "output": ["Removing runtime cache"],
             "result": {"type": "", "data": None},
             "finished": True,
             "code": 0,
             "error": "",
-            "last_status": 1,
+            "last": 1,
         }
         httpretty.register_uri(
             httpretty.GET,
-            "http://test-server/__api__/tasks/this_is_a_task_id",
-            body=json.dumps(mocked_task_status),
+            "http://test-server/__api__/v1/tasks/this_is_a_task_id",
+            body=json.dumps(mocked_task),
             status=200,
             forcing_headers={"Content-Type": "application/json"},
         )
 
         captured_output = io.StringIO()
         sys.stdout = captured_output
-        ce.delete_runtime_cache(language="Python", version="1.2.3", image_name="teapot", dry_run=False)
+        result, task = ce.delete_runtime_cache(language="Python", version="1.2.3", image_name="teapot", dry_run=False)
         sys.stdout = sys.__stdout__
 
         # Print expectations
@@ -175,7 +177,8 @@ class TestSystemRuntimeCachesAPI(TestCase):
         # self.assertEqual(output_lines[0], "Cache deletion finished")
 
         # Result expectations
-        self.assertDictEqual(mocked_task_status, ce.task_status)
+        self.assertDictEqual(mocked_delete_output, result)
+        self.assertDictEqual(mocked_task, task)
 
     # RSConnectExecutor.delete_runtime_cache() raises the correct error
     @httpretty.activate(verbose=True, allow_net_connect=False)

--- a/tests/test_main_content.py
+++ b/tests/test_main_content.py
@@ -72,16 +72,15 @@ def register_uris(connect_server: str):
     )
     httpretty.register_uri(
         httpretty.GET,
-        f"{connect_server}/__api__/tasks/1234",
+        f"{connect_server}/__api__/v1/tasks/1234",
         body="""{
             "id": "1234",
-            "user_id": 0,
-            "status": ["status1", "status2", "status3"],
+            "output": ["status1", "status2", "status3"],
             "result": {"type": "", "data": ""},
             "finished": true,
             "code": 0,
             "error": "",
-            "last_status": 0
+            "last": 0
         }""",
         adding_headers={"Content-Type": "application/json"},
     )


### PR DESCRIPTION
## Intent

The v0 task is still returned by the v0 deploy endpoint.

* poll-wait is an integer, not a float, and is used to configure the long-poll task requests against the Connect server.

* task_get() calls /v1/tasks/{id}. It takes first and wait arguments, indicating the starting point for requested output and the duration for long-poll requests.

* wait_for_task() does no sleeping, but asks task_get() to perform a long-poll with its wait argument.

* output_task_log() sends every output line to the log callback. It previously used data abut the last-line to determine when to send lines, but that is unnecessary, as wait_for_task() requests only new lines from task_get().

* RSConnectExecutor.delete_runtime_cache() returns its delete result and task for easier testing. It no longer stores state on the object.

fixes #608

## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers

* deploy any content and confirm that the output is shown.
* delete runtime caches and confirm that the output is shown.
* queue and run any content rebuild and confirm that the output is shown.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [x] I have updated all related GitHub issues to reflect their current state.
