### PR TITLE
Remove bloat from GH Actions Docker

### DIFF
--- a/.github/workflows/deploy_tests.yml
+++ b/.github/workflows/deploy_tests.yml
@@ -46,7 +46,7 @@ jobs:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
         - name: Delete dotnet to save space
-          run: sudo rm -rf /usr/share/dotnet
+          run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android
 
         - uses: actions/checkout@v4
           with:

--- a/.github/workflows/deploy_tests.yml
+++ b/.github/workflows/deploy_tests.yml
@@ -45,7 +45,7 @@ jobs:
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
-        - name: Delete dotnet to save space
+        - name: Delete unused stuff to save space
           run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android
 
         - uses: actions/checkout@v4


### PR DESCRIPTION
Nightly tests have been failing because GH Actions Docker container has run out of space.  This PR removes some bloatware.