### PR TITLE
add ability to override python version

### DIFF
--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -1732,6 +1732,7 @@ def get_python_env_info(
     file_name: str,
     python: str | None,
     force_generate: bool = False,
+    override_python_version: str | None = None,
 ) -> tuple[str, Environment]:
     """
     Gathers the python and environment information relating to the specified file
@@ -1751,6 +1752,9 @@ def get_python_env_info(
         raise RSConnectException(environment.error)
     logger.debug("Python: %s" % python)
     logger.debug("Environment: %s" % pformat(environment._asdict()))
+
+    if override_python_version:
+        environment = environment._replace(python = override_python_version)
 
     return python, environment
 
@@ -2243,6 +2247,7 @@ def create_python_environment(
     directory: str,
     force_generate: bool = False,
     python: Optional[str] = None,
+    override_python_version: Optional[str] = None
 ) -> Environment:
     module_file = fake_module_file_from_directory(directory)
 
@@ -2253,7 +2258,7 @@ def create_python_environment(
     _warn_if_environment_directory(directory)
 
     # with cli_feedback("Inspecting Python environment"):
-    _, environment = get_python_env_info(module_file, python, force_generate)
+    _, environment = get_python_env_info(module_file, python, force_generate, override_python_version)
 
     if force_generate:
         _warn_on_ignored_requirements(directory, environment.filename)

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -891,6 +891,14 @@ def _warn_on_ignored_requirements(directory: str, requirements_file_name: str):
     ),
 )
 @click.option(
+    "--override-python-version",
+    "-op",
+    help=(
+        "An optional python version to use instead of the version from "
+        "the detected environment."
+    )
+)
+@click.option(
     "--force-generate",
     "-g",
     is_flag=True,
@@ -920,6 +928,7 @@ def deploy_notebook(
     app_id: Optional[str],
     title: Optional[str],
     python: Optional[str],
+    override_python_version: Optional[str],
     force_generate: bool,
     verbose: int,
     file: str,
@@ -945,7 +954,7 @@ def deploy_notebook(
     _warn_on_ignored_manifest(base_dir)
     _warn_if_no_requirements_file(base_dir)
     _warn_if_environment_directory(base_dir)
-    python, environment = get_python_env_info(file, python, force_generate)
+    python, environment = get_python_env_info(file, python, force_generate, override_python_version)
 
     if force_generate:
         _warn_on_ignored_requirements(base_dir, environment.filename)
@@ -1032,6 +1041,14 @@ def deploy_notebook(
     ),
 )
 @click.option(
+    "--override-python-version",
+    "-op",
+    help=(
+        "An optional python version to use instead of the version from "
+        "the detected environment."
+    )
+)
+@click.option(
     "--force-generate",
     "-g",
     is_flag=True,
@@ -1050,6 +1067,7 @@ def deploy_voila(
     path: str,
     entrypoint: Optional[str],
     python: Optional[str],
+    override_python_version: Optional[str],
     force_generate: bool,
     extra_files: tuple[str, ...],
     exclude: tuple[str, ...],
@@ -1078,6 +1096,7 @@ def deploy_voila(
         path if isdir(path) else dirname(path),
         force_generate,
         python,
+        override_python_version
     )
 
     ce = RSConnectExecutor(
@@ -1231,6 +1250,14 @@ def deploy_manifest(
     ),
 )
 @click.option(
+    "--override-python-version",
+    "-op",
+    help=(
+        "An optional python version to use instead of the version from "
+        "the detected environment."
+    )
+)
+@click.option(
     "--force-generate",
     "-g",
     is_flag=True,
@@ -1257,6 +1284,7 @@ def deploy_quarto(
     exclude: tuple[str, ...],
     quarto: Optional[str],
     python: Optional[str],
+    override_python_version: Optional[str],
     force_generate: bool,
     verbose: int,
     file_or_directory: str,
@@ -1292,7 +1320,7 @@ def deploy_quarto(
         _warn_if_environment_directory(base_dir)
 
         with cli_feedback("Inspecting Python environment"):
-            python, environment = get_python_env_info(module_file, python, force_generate)
+            python, environment = get_python_env_info(module_file, python, force_generate, override_python_version)
 
             if force_generate:
                 _warn_on_ignored_requirements(base_dir, environment.filename)
@@ -1585,6 +1613,14 @@ def generate_deploy_python(app_mode: AppMode, alias: str, min_version: str, desc
         ),
     )
     @click.option(
+    "--override-python-version",
+    "-op",
+    help=(
+        "An optional python version to use instead of the version from "
+        "the detected environment."
+    )
+    )
+    @click.option(
         "--force-generate",
         "-g",
         is_flag=True,
@@ -1612,6 +1648,7 @@ def generate_deploy_python(app_mode: AppMode, alias: str, min_version: str, desc
         app_id: Optional[str],
         title: Optional[str],
         python: Optional[str],
+        override_python_version: Optional[str],
         force_generate: bool,
         verbose: int,
         directory: str,
@@ -1634,6 +1671,7 @@ def generate_deploy_python(app_mode: AppMode, alias: str, min_version: str, desc
             directory,
             force_generate,
             python,
+            override_python_version=override_python_version
         )
 
         if app_mode == AppModes.PYTHON_SHINY:
@@ -1753,6 +1791,14 @@ def write_manifest():
     + "The Python environment must have the rsconnect package installed.",
 )
 @click.option(
+    "--override-python-version",
+    "-op",
+    help=(
+        "An optional python version to use instead of the version from "
+        "the detected environment."
+    )
+)
+@click.option(
     "--force-generate",
     "-g",
     is_flag=True,
@@ -1773,6 +1819,7 @@ def write_manifest_notebook(
     ctx: click.Context,
     overwrite: bool,
     python: Optional[str],
+    override_python_version: Optional[str],
     force_generate: bool,
     verbose: int,
     file: str,
@@ -1796,7 +1843,7 @@ def write_manifest_notebook(
             raise RSConnectException("manifest.json already exists. Use --overwrite to overwrite.")
 
     with cli_feedback("Inspecting Python environment"):
-        python, environment = get_python_env_info(file, python, force_generate)
+        python, environment = get_python_env_info(file, python, force_generate, override_python_version)
 
     with cli_feedback("Creating manifest.json"):
         environment_file_exists = write_notebook_manifest_json(


### PR DESCRIPTION
## Intent

I am unable to deploy to connect from my development server because the python I'm using is newer than the versions available on connect. I would like to be able to tell rsconnect-python to use a different python version, so I patched in that feature.

## Type of Change

- [x] Bug Fix           <!-- A change which fixes an existing issue --> 
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

This PR modifies the environment detection code to add an override option where the `Environment` object is cloned
with the updated python version. This was weaved out to the CLI.

## Automated Tests

No tests written, would like feedback on idea / style / etc. before adding tests. Someone more familiar with the project could also provide direction for testing this feature.

## Directions for Reviewers

Try deploying something and using `--override-python-version <version>` or `-op <version>`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
