### PR TITLE
Document the `--parallelism` setting flag for content build commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,6 +912,22 @@ from the local state file, the content deployed to the server remains unchanged.
 rsconnect content build rm --guid 4ffc819c-065c-420c-88eb-332db1133317
 ```
 
+### Rebuilding lots of content
+
+When attempting to rebuild a long list of content, it is recommended to first build a sub-set of the content list.
+First choose 1 or 2 Python and R content items for each version of Python and R on the server. Try to choose content
+items that have the most dependencies in common with other content items on the server. Build these content items
+first with the `rsconnect content build run` command. This will "warm" the Python and R environment cache for subsequent
+content builds. Once these initial builds are complete, add the remaining content items to the list of "tracked" content
+and execute another `rsconnect content build run` command.
+
+To execute multiple content builds simultaniously, use the `rsconnect content build run --parallelism` flag to increase the
+number of concurrent builds. By default, each content item is built serially. Increasing the build parallelism can reduce the total
+time needed to rebuild a long list of content items. We recommend starting with a low parallelism setting (2-3) and increasing
+from there to avoid overloading the Connect server with concurrent build operations. Remember that these builds are executing on the
+Connect server which consumes CPU, RAM, and i/o bandwidth that would otherwise we allocated for Python and R applications
+running on the server.
+
 ## Common Usage Examples
 
 ### Searching for content


### PR DESCRIPTION
Fixes #613 

## Intent

Document the `--parallelism` argument of the `rsconnect build build run` subcommand.

## Type of Change

Docs only.

- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
<!-- Describe how you solved this problem and any trade-offs you encountered. -->
<!-- Link any additional documentation associated with this change here -->

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
