### PR TITLE
fix: add content build run --force flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added validation for required flags for the `rsconnect system caches delete` command.
+- Added `--force` flag to `rsconnect content build run` command. This allows users
+  to force builds when a build is already marked as running. (#630)
 
 ## [1.25.0] - 2024-12-18
 

--- a/README.md
+++ b/README.md
@@ -886,7 +886,9 @@ build all "tracked" content that has the status `NEEDS_BUILD`.
 > To re-run failed builds, use `rsconnect content build run --retry`. This will build
 all tracked content in any of the following states: `[NEEDS_BUILD, ABORTED, ERROR, RUNNING]`.
 >
-> If you encounter an error stating that a build operation is already running, you can use `rsconnect content build run --force`. This will override this check and build any content marked as `NEEDS_BUILD`.
+> If you encounter an error indicating that a build operation is already in progress,
+you can use `rsconnect content build run --force` to bypass the check and proceed with building content marked as `NEEDS_BUILD`.
+Ensure no other build operation is actively running before using the `--force` option.
 
 ```bash
 rsconnect content build run

--- a/README.md
+++ b/README.md
@@ -885,6 +885,8 @@ build all "tracked" content that has the status `NEEDS_BUILD`.
 
 > To re-run failed builds, use `rsconnect content build run --retry`. This will build
 all tracked content in any of the following states: `[NEEDS_BUILD, ABORTED, ERROR, RUNNING]`.
+>
+> If you encounter an error stating that a build operation is already running, you can use `rsconnect content build run --force`. This will override this check and build any content marked as `NEEDS_BUILD`.
 
 ```bash
 rsconnect content build run

--- a/rsconnect/actions_content.py
+++ b/rsconnect/actions_content.py
@@ -136,8 +136,8 @@ def build_start(
     build_store = ensure_content_build_store(connect_server)
     if build_store.get_build_running() and not force:
         raise RSConnectException(
-            "There is already a build running on this server: %s. "
-            "Use the '--force' flag to override this check." % connect_server.url
+            "A content build operation targeting '%s' is still running, or exited abnormally. "
+            "Use the '--force' option to override this check." % connect_server.url
         )
 
     # prompt the user to confirm that they want to --force a build.

--- a/rsconnect/actions_content.py
+++ b/rsconnect/actions_content.py
@@ -148,8 +148,7 @@ def build_start(
         build_add_content(connect_server, all_content)
     else:
         # --retry is shorthand for --aborted --error --running
-        # --force has the same behavior as --retry and also ignores when rsconnect_build_running=true
-        if retry or force:
+        if retry:
             aborted = True
             error = True
             running = True

--- a/rsconnect/actions_content.py
+++ b/rsconnect/actions_content.py
@@ -140,15 +140,6 @@ def build_start(
             "Use the '--force' option to override this check." % connect_server.url
         )
 
-    # prompt the user to confirm that they want to --force a build.
-    if force:
-        logger.warning("Please ensure a build is not already running in another terminal before proceeding.")
-        user_input = input("Proceed with the build? Type 'yes' to confirm, any other key to cancel: ").strip().lower()
-        if user_input != "yes":
-            logger.warning("Build aborted.")
-            return
-        logger.info("Proceeding with the build...")
-
     # if we are re-building any already "tracked" content items, then re-add them to be safe
     if all:
         logger.info("Adding all content to build...")

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -2755,6 +2755,11 @@ def get_build_logs(
     is_flag=True,
     help="Log stacktraces from exceptions during background operations.",
 )
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Always build content even if a build is already marked as running. Builds the same content as --retry.",
+)
 @click.pass_context
 def start_content_build(
     ctx: click.Context,
@@ -2772,6 +2777,7 @@ def start_content_build(
     poll_wait: int,
     format: LogOutputFormat.All,
     debug: bool,
+    force: bool,
     verbose: int,
 ):
     set_verbosity(verbose)
@@ -2781,7 +2787,7 @@ def start_content_build(
         ce = RSConnectExecutor(ctx, name, server, api_key, insecure, cacert, logger=None).validate_server()
         if not isinstance(ce.remote_server, RSConnectServer):
             raise RSConnectException("rsconnect content build run` requires a Posit Connect server.")
-        build_start(ce.remote_server, parallelism, aborted, error, running, retry, all, poll_wait, debug)
+        build_start(ce.remote_server, parallelism, aborted, error, running, retry, all, poll_wait, debug, force)
 
 
 @cli.group(no_args_is_help=True, help="Interact with Posit Connect's system API.")

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -2758,7 +2758,7 @@ def get_build_logs(
 @click.option(
     "--force",
     is_flag=True,
-    help="Always build content even if a build is already marked as running. Builds the same content as --retry.",
+    help="Always build content even if a build is already marked as running.",
 )
 @click.pass_context
 def start_content_build(

--- a/rsconnect/utils_package.py
+++ b/rsconnect/utils_package.py
@@ -246,7 +246,7 @@ def fix_starlette_requirements(
         if compare_semvers(starlette_req.specs[0].version, "0.35.0") >= 0:
             # starlette is in requirements.txt, but with a version spec that is
             # not compatible with this version of Connect.
-            logger.warn(
+            logger.warning(
                 "Starlette version is 0.35.0 or greater, but this version of Connect "
                 "requires starlette<0.35.0. Setting to <0.35.0."
             )

--- a/tests/test_main_content.py
+++ b/tests/test_main_content.py
@@ -272,8 +272,11 @@ class TestContentSubcommand(unittest.TestCase):
         apply_common_args(args, server=self.connect_server, key=self.api_key)
         result = runner.invoke(cli, args)
         self.assertEqual(result.exit_code, 1)
-        self.assertRegex(result.output, "There is already a build running on this server")
-        self.assertRegex(result.output, "Use the '--force' flag to override this check")
+        self.assertRegex(
+            result.output,
+            "A content build operation targeting 'http://localhost:3939' is still running, or exited abnormally",
+        )
+        self.assertRegex(result.output, "Use the '--force' option to override this check")
 
     @httpretty.activate(verbose=True, allow_net_connect=False)
     def test_build_force_abort(self):

--- a/tests/test_main_content.py
+++ b/tests/test_main_content.py
@@ -279,31 +279,7 @@ class TestContentSubcommand(unittest.TestCase):
         self.assertRegex(result.output, "Use the '--force' option to override this check")
 
     @httpretty.activate(verbose=True, allow_net_connect=False)
-    def test_build_force_abort(self):
-        register_uris(self.connect_server)
-        runner = CliRunner()
-
-        args = ["content", "build", "add", "-g", "7d59c5c7-c4a7-4950-acc3-3943b7192bc4"]
-        apply_common_args(args, server=self.connect_server, key=self.api_key)
-        result = runner.invoke(cli, args)
-        self.assertEqual(result.exit_code, 0, result.output)
-        self.assertTrue(os.path.exists("%s/%s.json" % (TEMP_DIR, _normalize_server_url(self.connect_server))))
-
-        # set rsconnect_build_running to true
-        # --force flag should ignore this and not fail.
-        self.build_store.set_build_running(True)
-
-        # mock "no" input to simulate user response to prompt
-        with patch("builtins.input", return_value="no"), self.assertLogs("rsconnect") as log:
-            args = ["content", "build", "run", "--force"]
-            apply_common_args(args, server=self.connect_server, key=self.api_key)
-            result = runner.invoke(cli, args)
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("Please ensure a build is not already running in another terminal", log.output[0])
-            self.assertIn("Build aborted", log.output[1])
-
-    @httpretty.activate(verbose=True, allow_net_connect=False)
-    def test_build_force_success(self):
+    def test_build_force(self):
         register_uris(self.connect_server)
         runner = CliRunner()
 
@@ -333,14 +309,10 @@ class TestContentSubcommand(unittest.TestCase):
         # --force flag should ignore this and not fail.
         self.build_store.set_build_running(True)
 
-        # mock "yes" input to simulate user response to prompt
-        with patch("builtins.input", return_value="yes"), self.assertLogs("rsconnect") as log:
-            args = ["content", "build", "run", "--force"]
-            apply_common_args(args, server=self.connect_server, key=self.api_key)
-            result = runner.invoke(cli, args)
-            self.assertEqual(result.exit_code, 0)
-            self.assertIn("Please ensure a build is not already running in another terminal", log.output[0])
-            self.assertIn("Proceeding with the build...", log.output[1])
+        args = ["content", "build", "run", "--force"]
+        apply_common_args(args, server=self.connect_server, key=self.api_key)
+        result = runner.invoke(cli, args)
+        self.assertEqual(result.exit_code, 0, result.output)
 
         # check that the build succeeded
         args = [

--- a/tests/test_main_content.py
+++ b/tests/test_main_content.py
@@ -3,7 +3,6 @@ import json
 import shutil
 import tarfile
 import unittest
-from unittest.mock import patch
 
 import httpretty
 from click.testing import CliRunner


### PR DESCRIPTION
## Intent

Provide a way to recover from `already a build running` errors without having to manually edit the JSON state file

Fixes #603 #620 https://github.com/rstudio/connect/issues/29298

## Type of Change

- [x] Bug Fix           <!-- A change which fixes an existing issue --> 
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

- add a `--force` flag to the `content build run` command. this ignores `rsconnect_build_running` being set to `true` in the state file to allow users to recover from `already a build running` errors without having to manually edit the state file

- remove the `rsconnect_build_running` check from the `content build [add,remove]` commands

- `--force` will only build `NEEDS_ BUILD` content by default, but can be combined with `--retry` to build content in other states

- update deprecated `logger.warn` usage to `logger.warning`
   - https://docs.python.org/3/library/logging.html#logging.Logger.warning
   > Note
      There is an obsolete method warn which is functionally identical to warning. As warn is deprecated, please do not use it use warning instead.


## Automated Tests

added tests for `--force` and `already a build running` conditions

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
