### PR TITLE
chore(ci): Remove IMAGE_OS setting

### DIFF
--- a/.github/workflows/deploy_tests.yml
+++ b/.github/workflows/deploy_tests.yml
@@ -13,7 +13,7 @@ jobs:
             fetch-depth: 0
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            
+
         - uses: actions/setup-python@v4
           with:
             python-version: 3.8.x
@@ -44,7 +44,7 @@ jobs:
             fetch-depth: 0
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
+
         - name: Delete unused stuff to save space
           run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android
 
@@ -58,18 +58,18 @@ jobs:
                 examples
             sparse-checkout-cone-mode: false
             token: ${{ secrets.CONNECT_PAT }}
-    
+
         - name: Build docker container-image
           run: |
             cd test/connect-rsconnect-python/test/rsconnect-python/
             docker compose --profile rsconnect build
-    
+
         - name: Restore dist
           uses: actions/download-artifact@v4
           with:
             name: distributions
             path: dist/
-       
+
         - name: Run rsconnect-python Tests
           env:
             CONNECT_LICENSE: "${{ secrets.RSC_LICENSE }}"
@@ -81,7 +81,6 @@ jobs:
             QUARTO_VERSION: "1.4.546"
             # This allows us to start Connect separately in our own docker container
             CONNECT_SERVER: "http://localhost:3939"
-            IMAGE_OS: "rstudio/connect:ubuntu22"
             remote: "yes"
           run: |
             cd integration-testing
@@ -90,7 +89,7 @@ jobs:
             docker compose up -d connect-cli
             docker compose up -d client-cli
             docker compose run --rm client-cli just ../test/connect-rsconnect-python/test/rsconnect-python/_start-dev
-        
+
         # Videos are captured whether the suite fails or passes
         - name: Save videos
           uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -230,7 +230,6 @@ jobs:
 
               # This allows us to start Connect separately in our own docker container
               CONNECT_SERVER: "http://localhost:3939"
-              IMAGE_OS: "rstudio/connect:ubuntu22"
               remote: "yes"
             run: |
               cd integration-testing

--- a/integration-testing/docker-compose.yml
+++ b/integration-testing/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       QUARTO_VERSION: ${QUARTO_VERSION}
       PY_VERSION: ${PY_VERSION}
       API_KEY: ${ADMIN_API_KEY}
-      IMAGE_OS: ${IMAGE_OS}
 
   # customized connect built with updated quarto version
   # used for nightly deploy_tests.yml that include quarto projects


### PR DESCRIPTION
Closes #633. Turns out we already are using public images for testing, and from what I infer from #588, this was just being added to prevent a script from looking for it and erroring if it wasn't set. Due to changes in the Connect source, this variable isn't being used anymore, so we can drop the reference.