### PR TITLE
fix: display system error message when rsconnect.environment inspection fails

### DIFF
--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -1724,13 +1724,13 @@ def inspect_environment(
 
     try:
         environment_json = check_output(args, text=True)
-    except subprocess.CalledProcessError as e:
-        raise RSConnectException(f"Error inspecting environment (subprocess failed): {e.output}") from e
+    except Exception as e:
+        raise RSConnectException("Error inspecting environment (subprocess failed)") from e
 
     try:
         environment_data = json.loads(environment_json)
     except json.JSONDecodeError as e:
-        raise RSConnectException(f"Error parsing environment JSON: {str(e)}") from e
+        raise RSConnectException("Error parsing environment JSON") from e
 
     try:
         return MakeEnvironment(**environment_data)
@@ -1738,7 +1738,7 @@ def inspect_environment(
         system_error_message = environment_data.get("error")
         if system_error_message:
             raise RSConnectException(f"Error creating environment: {system_error_message}") from e
-        raise RSConnectException(f"Error constructing environment object: {str(e)}") from e
+        raise RSConnectException("Error constructing environment object") from e
 
 
 def get_python_env_info(

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1214,11 +1214,10 @@ class TestBundle(TestCase):
 
     def test_inspect_environment_catches_type_error(self):
         with pytest.raises(RSConnectException) as exec_info:
-            inspect_environment(sys.executable, None) # type: ignore
+            inspect_environment(sys.executable, None)  # type: ignore
 
         assert isinstance(exec_info.value, RSConnectException)
         assert isinstance(exec_info.value.__cause__, TypeError)
-
 
 
 @pytest.mark.parametrize(

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1212,6 +1212,14 @@ class TestBundle(TestCase):
         assert environment is not None
         assert environment.python != ""
 
+    def test_inspect_environment_catches_type_error(self):
+        with pytest.raises(RSConnectException) as exec_info:
+            inspect_environment(sys.executable, None) # type: ignore
+
+        assert isinstance(exec_info.value, RSConnectException)
+        assert isinstance(exec_info.value.__cause__, TypeError)
+
+
 
 @pytest.mark.parametrize(
     (


### PR DESCRIPTION
When calling `python -m rsconnect.environment` with invalid arguments, `subprocess.check_output` returns a JSON object with a single error field. Passing this result directly to `MakeEnvironment` results in a `KeyError` since `MakeEnvironment` requires additional arguments. This change catches the TypeError and surfaces the underlying error message from `subprocess.check_output`. 

Addresses #635 