### PR TITLE
Add `*.lic` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ coverage.xml
 # Temporary dev files
 vetiver-testing/rsconnect_api_keys.json
 /pip-wheel-metadata/
+
+# license files should not be commited to this repository
+*.lic


### PR DESCRIPTION
Adding `*.lic` to `.gitignore` so that accidentally committing license files requires additional steps.