### PR TITLE
Add logs url on failure

### DIFF
--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -355,7 +355,7 @@ class RSConnectClient(HTTPServer):
             raise RSConnectException(
                 "Could not access the deployed content. "
                 + "The app might not have started successfully."
-                + f"\n\t For more information: {self.app_config(app_guid)['logs_url']}"
+                + f"\n\t For more information: {self.app_config(app_guid).get('logs_url')}"
             )
 
     def bundle_download(self, content_guid: str, bundle_id: str) -> HTTPResponse:

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -354,8 +354,8 @@ class RSConnectClient(HTTPServer):
         if self.is_app_failed_response(response):
             raise RSConnectException(
                 "Could not access the deployed content. "
-                + "The app might not have started successfully. "
-                + "Visit it in Connect to view the logs."
+                + "The app might not have started successfully."
+                + f"\n\tFor more information: {self.app_config(app_guid)['logs_url']}"
             )
 
     def bundle_download(self, content_guid: str, bundle_id: str) -> HTTPResponse:

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -355,7 +355,7 @@ class RSConnectClient(HTTPServer):
             raise RSConnectException(
                 "Could not access the deployed content. "
                 + "The app might not have started successfully."
-                + f"\n\tFor more information: {self.app_config(app_guid)['logs_url']}"
+                + f"\n\t For more information: {self.app_config(app_guid)['logs_url']}"
             )
 
     def bundle_download(self, content_guid: str, bundle_id: str) -> HTTPResponse:


### PR DESCRIPTION
## Intent
Add the logs URL to the error message so that folks find the logs easier.

Resolves: #636


## Type of Change
- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach
Fetch and add the logs URL to the error message

## Automated Tests
None were broken or added.

## Directions for Reviewers
Output from testing this locally:

```
% rsconnect deploy shiny --name radixu .
Validating server... 	[OK]
Validating app mode... 	[OK]
Making bundle ... 	[OK]
Deploying bundle ... 	[OK]
Saving deployed information... 	[OK]
Building Python Shiny application...
...
Launching Python Shiny application...
Deployment completed successfully.
	 Dashboard content URL: https://rsc.radixu.com/connect/#/apps/09bfbb6a-7e7c-4a37-bafd-9a0bd7b4b67c/access
	 Direct content URL: https://rsc.radixu.com/content/09bfbb6a-7e7c-4a37-bafd-9a0bd7b4b67c/
Verifying deployed content... 	[ERROR]: Could not access the deployed content. The app might not have started successfully.
	For more information: https://rsc.radixu.com/connect/#/apps/09bfbb6a-7e7c-4a37-bafd-9a0bd7b4b67c/logs
Error: Could not access the deployed content. The app might not have started successfully.
	For more information: https://rsc.radixu.com/connect/#/apps/09bfbb6a-7e7c-4a37-bafd-9a0bd7b4b67c/logs
```

## Checklist
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
