### PR TITLE
Parser for interpreter version requirements from setup.cfg .python-version 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,9 +92,3 @@ typeCheckingMode = "strict"
 reportPrivateUsage = "none"
 reportUnnecessaryIsInstance = "none"
 reportUnnecessaryComparison = "none"
-
-[tool.uv.sources]
-rsconnect-python = { workspace = true }
-
-[tool.uv.workspace]
-members = ["tests/testdata/python-project"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,3 +92,9 @@ typeCheckingMode = "strict"
 reportPrivateUsage = "none"
 reportUnnecessaryIsInstance = "none"
 reportUnnecessaryComparison = "none"
+
+[tool.uv.sources]
+rsconnect-python = { workspace = true }
+
+[tool.uv.workspace]
+members = ["tests/testdata/python-project"]

--- a/rsconnect/pyproject.py
+++ b/rsconnect/pyproject.py
@@ -7,6 +7,7 @@ but not from setup.py due to its dynamic nature.
 
 import pathlib
 import typing
+import configparser
 
 try:
     import tomllib
@@ -24,12 +25,29 @@ def lookup_metadata_file(directory: typing.Union[str, pathlib.Path]) -> typing.L
     directory = pathlib.Path(directory)
 
     def _generate():
-        for filename in ("pyproject.toml", "setup.cfg", ".python-version"):
+        for filename in (".python-version", "pyproject.toml", "setup.cfg"):
             path = directory / filename
             if path.is_file():
                 yield (filename, path)
 
     return list(_generate())
+
+
+def get_python_requires_parser(
+    metadata_file: pathlib.Path,
+) -> typing.Optional[typing.Callable[[pathlib.Path], typing.Optional[str]]]:
+    """Given the metadata file, return the appropriate parser function.
+
+    The returned function takes a pathlib.Path and returns the parsed value.
+    """
+    if metadata_file.name == "pyproject.toml":
+        return parse_pyproject_python_requires
+    elif metadata_file.name == "setup.cfg":
+        return parse_setupcfg_python_requires
+    elif metadata_file.name == ".python-version":
+        return parse_pyversion_python_requires
+    else:
+        return None
 
 
 def parse_pyproject_python_requires(pyproject_file: pathlib.Path) -> typing.Optional[str]:
@@ -43,3 +61,27 @@ def parse_pyproject_python_requires(pyproject_file: pathlib.Path) -> typing.Opti
     pyproject = tomllib.loads(content)
 
     return pyproject.get("project", {}).get("requires-python", None)
+
+
+def parse_setupcfg_python_requires(setupcfg_file: pathlib.Path) -> typing.Optional[str]:
+    """Parse the python_requires field from a setup.cfg file.
+
+    Assumes that the setup.cfg file exists, is accessible and well formatted.
+
+    Returns None if the field is not found.
+    """
+    config = configparser.ConfigParser()
+    config.read(setupcfg_file)
+
+    return config.get("options", "python_requires", fallback=None)
+
+
+def parse_pyversion_python_requires(pyversion_file: pathlib.Path) -> typing.Optional[str]:
+    """Parse the python version from a .python-version file.
+
+    Assumes that the .python-version file exists, is accessible and well formatted.
+
+    Returns None if the field is not found.
+    """
+    content = pyversion_file.read_text()
+    return content.strip()

--- a/rsconnect/pyproject.py
+++ b/rsconnect/pyproject.py
@@ -41,4 +41,5 @@ def parse_pyproject_python_requires(pyproject_file: pathlib.Path) -> typing.Opti
     """
     content = pyproject_file.read_text()
     pyproject = tomllib.loads(content)
+
     return pyproject.get("project", {}).get("requires-python", None)

--- a/rsconnect/pyproject.py
+++ b/rsconnect/pyproject.py
@@ -41,5 +41,4 @@ def parse_pyproject_python_requires(pyproject_file: pathlib.Path) -> typing.Opti
     """
     content = pyproject_file.read_text()
     pyproject = tomllib.loads(content)
-
     return pyproject.get("project", {}).get("requires-python", None)

--- a/rsconnect/pyproject.py
+++ b/rsconnect/pyproject.py
@@ -21,6 +21,9 @@ def lookup_metadata_file(directory: typing.Union[str, pathlib.Path]) -> typing.L
 
     The returned value is either a list of tuples [(filename, path)] or
     an empty list [] if no metadata file was found.
+
+    The metadata files are returned in the priority they should be processed
+    to determine the python version requirements.
     """
     directory = pathlib.Path(directory)
 
@@ -64,7 +67,7 @@ def parse_pyproject_python_requires(pyproject_file: pathlib.Path) -> typing.Opti
 
 
 def parse_setupcfg_python_requires(setupcfg_file: pathlib.Path) -> typing.Optional[str]:
-    """Parse the python_requires field from a setup.cfg file.
+    """Parse the options.python_requires field from a setup.cfg file.
 
     Assumes that the setup.cfg file exists, is accessible and well formatted.
 

--- a/rsconnect/pyproject.py
+++ b/rsconnect/pyproject.py
@@ -36,7 +36,7 @@ def lookup_metadata_file(directory: typing.Union[str, pathlib.Path]) -> typing.L
     return list(_generate())
 
 
-def get_python_requires_parser(
+def get_python_version_requirement_parser(
     metadata_file: pathlib.Path,
 ) -> typing.Optional[typing.Callable[[pathlib.Path], typing.Optional[str]]]:
     """Given the metadata file, return the appropriate parser function.

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -17,7 +17,7 @@ PROJECTS_DIRECTORY = os.path.abspath(os.path.join(HERE, "testdata", "python-proj
 # Most of this tests, verify against three fixture projects that are located in PROJECTS_DIRECTORY
 # - using_pyproject: contains a pyproject.toml file with a project.requires-python field
 # - using_setupcfg: contains a setup.cfg file with a options.python_requires field
-# - using_pyversion: contains a .python-version file and a pyproject.toml file without any version constraint.
+# - using_pyversion: contains a .python-version file and pyproject.toml, setup.cfg without any version constraint.
 # - allofthem: contains all metadata files all with different version constraints.
 
 
@@ -55,6 +55,7 @@ def test_python_project_metadata_detect(project_dir, expected):
     ids=["pyproject.toml", "setup.cfg", ".python-version", "invalid"],
 )
 def test_get_python_requires_parser(filename, expected_parser):
+    """Test that given a metadata file name, the correct parser is returned."""
     metadata_file = pathlib.Path(PROJECTS_DIRECTORY) / filename
     parser = get_python_requires_parser(metadata_file)
     assert parser == expected_parser
@@ -82,7 +83,7 @@ def test_python_project_metadata_missing(project_dir):
     ids=["option-exists", "option-missing"],
 )
 def test_pyprojecttoml_python_requires(project_dir, expected):
-    """Test that the python_requires field is correctly parsed from pyproject.toml.
+    """Test that the requires-python field is correctly parsed from pyproject.toml.
 
     Both when the option exists or when it missing in the pyproject.toml file.
     """
@@ -99,6 +100,10 @@ def test_pyprojecttoml_python_requires(project_dir, expected):
     ids=["option-exists", "option-missing"],
 )
 def test_setupcfg_python_requires(tmp_path, project_dir, expected):
+    """Test that the python_requires field is correctly parsed from setup.cfg.
+
+    Both when the option exists or when it missing in the file.
+    """
     setupcfg_file = pathlib.Path(project_dir) / "setup.cfg"
     assert parse_setupcfg_python_requires(setupcfg_file) == expected
 
@@ -107,11 +112,14 @@ def test_setupcfg_python_requires(tmp_path, project_dir, expected):
     "project_dir, expected",
     [
         (os.path.join(PROJECTS_DIRECTORY, "using_pyversion"), ">=3.8, <3.12"),
-        # There is no case (option-missing) where the .python-version file is empty,
-        # so we don't test that.
     ],
     ids=["option-exists"],
 )
 def test_pyversion_python_requires(tmp_path, project_dir, expected):
+    """Test that the python version is correctly parsed from .python-version.
+
+    We do not test the case where the option is missing, as an empty .python-version file
+    is not a valid case for a python project.
+    """
     versionfile = pathlib.Path(project_dir) / ".python-version"
     assert parse_pyversion_python_requires(versionfile) == expected

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -6,7 +6,7 @@ from rsconnect.pyproject import (
     parse_pyproject_python_requires,
     parse_setupcfg_python_requires,
     parse_pyversion_python_requires,
-    get_python_requires_parser,
+    get_python_version_requirement_parser,
 )
 
 import pytest
@@ -54,10 +54,10 @@ def test_python_project_metadata_detect(project_dir, expected):
     ],
     ids=["pyproject.toml", "setup.cfg", ".python-version", "invalid"],
 )
-def test_get_python_requires_parser(filename, expected_parser):
+def test_get_python_version_requirement_parser(filename, expected_parser):
     """Test that given a metadata file name, the correct parser is returned."""
     metadata_file = pathlib.Path(PROJECTS_DIRECTORY) / filename
-    parser = get_python_requires_parser(metadata_file)
+    parser = get_python_version_requirement_parser(metadata_file)
     assert parser == expected_parser
 
 

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -1,7 +1,14 @@
 import os
 import pathlib
+import tempfile
 
-from rsconnect.pyproject import lookup_metadata_file, parse_pyproject_python_requires
+from rsconnect.pyproject import (
+    lookup_metadata_file,
+    parse_pyproject_python_requires,
+    parse_setupcfg_python_requires,
+    parse_pyversion_python_requires,
+    get_python_requires_parser,
+)
 
 import pytest
 
@@ -23,11 +30,12 @@ PROJECTS_DIRECTORY = os.path.abspath(os.path.join(HERE, "testdata", "python-proj
         (
             os.path.join(PROJECTS_DIRECTORY, "using_pyversion"),
             (
-                "pyproject.toml",
                 ".python-version",
+                "pyproject.toml",
+                "setup.cfg",
             ),
         ),
-        (os.path.join(PROJECTS_DIRECTORY, "allofthem"), ("pyproject.toml", "setup.cfg", ".python-version")),
+        (os.path.join(PROJECTS_DIRECTORY, "allofthem"), (".python-version", "pyproject.toml", "setup.cfg")),
     ],
     ids=["pyproject.toml", "setup.cfg", ".python-version", "allofthem"],
 )
@@ -35,6 +43,22 @@ def test_python_project_metadata_detect(project_dir, expected):
     """Test that the metadata files are detected when they exist."""
     expectation = [(f, pathlib.Path(project_dir) / f) for f in expected]
     assert lookup_metadata_file(project_dir) == expectation
+
+
+@pytest.mark.parametrize(
+    "filename, expected_parser",
+    [
+        ("pyproject.toml", parse_pyproject_python_requires),
+        ("setup.cfg", parse_setupcfg_python_requires),
+        (".python-version", parse_pyversion_python_requires),
+        ("invalid.txt", None),
+    ],
+    ids=["pyproject.toml", "setup.cfg", ".python-version", "invalid"],
+)
+def test_get_python_requires_parser(filename, expected_parser):
+    metadata_file = pathlib.Path(PROJECTS_DIRECTORY) / filename
+    parser = get_python_requires_parser(metadata_file)
+    assert parser == expected_parser
 
 
 @pytest.mark.parametrize(
@@ -65,3 +89,30 @@ def test_pyprojecttoml_python_requires(project_dir, expected):
     """
     pyproject_file = pathlib.Path(project_dir) / "pyproject.toml"
     assert parse_pyproject_python_requires(pyproject_file) == expected
+
+
+@pytest.mark.parametrize(
+    "project_dir, expected",
+    [
+        (os.path.join(PROJECTS_DIRECTORY, "using_setupcfg"), ">=3.8"),
+        (os.path.join(PROJECTS_DIRECTORY, "using_pyversion"), None),
+    ],
+    ids=["option-exists", "option-missing"],
+)
+def test_setupcfg_python_requires(tmp_path, project_dir, expected):
+    setupcfg_file = pathlib.Path(project_dir) / "setup.cfg"
+    assert parse_setupcfg_python_requires(setupcfg_file) == expected
+
+
+@pytest.mark.parametrize(
+    "project_dir, expected",
+    [
+        (os.path.join(PROJECTS_DIRECTORY, "using_pyversion"), ">=3.8, <3.12"),
+        # There is no case (option-missing) where the .python-version file is empty,
+        # so we don't test that.
+    ],
+    ids=["option-exists"],
+)
+def test_pyversion_python_requires(tmp_path, project_dir, expected):
+    versionfile = pathlib.Path(project_dir) / ".python-version"
+    assert parse_pyversion_python_requires(versionfile) == expected

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -1,6 +1,5 @@
 import os
 import pathlib
-import tempfile
 
 from rsconnect.pyproject import (
     lookup_metadata_file,

--- a/tests/testdata/python-project/using_pyversion/setup.cfg
+++ b/tests/testdata/python-project/using_pyversion/setup.cfg
@@ -1,0 +1,4 @@
+[metadata]
+name = python-project
+version = 0.1.0
+description = Add your description here


### PR DESCRIPTION
## Intent

Second step toward supporting python interpreter version requirements in `manifest.json` generation.
This is a follow-up of https://github.com/posit-dev/rsconnect-python/pull/643 that adds support for the other two planned file formats.

## Type of Change

- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

Continuing with small incremental PRs approach to add support for each new format keeping the review effort minimal.

## Automated Tests

New tests were added for every function in the `test_pyproject.py` file.

## Directions for Reviewers

This continues in the direction of building all the necessary blocks without exposing the feature to the end user until the very end. The PR is based on the https://github.com/posit-dev/rsconnect-python/pull/643 code, so it should be reviewed only once the other PR is merged as it will influence this one.

