### PR TITLE
Support environment.python.requires option in manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [??] - ??
+
+### Added
+
+- `rsconnect` now detects Python interpreter version requirements from
+  `.python-version`, `pyproject.toml` and `setup.cfg`
+
 ## [1.25.2] - 2025-02-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -219,24 +219,34 @@ ensuring that you use the same Python that you use to run your Jupyter Notebook:
 #### Python Version
 
 When deploying Python content to Posit Connect,
-the server will require matching `<MAJOR.MINOR>` versions of Python. For example,
-a server with only Python 3.9 installed will fail to match content deployed with
-Python 3.8. Your administrator may also enable exact Python version matching which
-will be stricter and require matching major, minor, and patch versions. For more
-information see the [Posit Connect Admin Guide chapter titled Python Version
+the server will require a version of Python that matches the content
+requirements.
+
+For example, a server with only Python 3.9 installed will fail to match content
+that requires Python 3.8.
+
+`rsconnect` will supports detecting Python version requirements in 4 ways:
+    1. A `.python-version` file exists. In such case
+       `rsconnect` will use its content to determine the python version requirement.
+    2. A `pyproject.toml` with a `project.requires-python` field exists.
+       In such case the requirement specified in the field will be used
+       if no `.python-version` file exists.
+    3. A `setup.cfg` with a `options.python_requirs` field exists.
+       In such case the requirement specified in the field will be used
+       if no `.python-version` or `pyproject.toml` files exist.
+    4. If no other source of version requirement was found, then
+       the interpreter in use is considered the one required to run the content.
+
+On newer Posit Connect versions the requirement detected by `rsconnect` is
+always respected. Older Connect versions will instead rely only on the
+python version used to deploy the content to determine the requirement.
+
+For more information see the [Posit Connect Admin Guide chapter titled Python Version
 Matching](https://docs.posit.co/connect/admin/python/#python-version-matching).
 
-We recommend installing a version of Python on your client that is also available
-in your Connect installation. If that's not possible, you can override
-rsconnect-python's detected Python version and request a version of Python
-that is installed in Connect, For example, this command:
-
-```bash
-rsconnect deploy api --override-python-version 3.11.5 my-api/
-```
-
-will deploy the content in `my-api` while requesting that Connect
-use Python version 3.11.5.
+We recommend providing a `pyproject.toml` with a `project.requires-python` field
+if the deployed content is an installable package and a `.python-version` file
+for plain directories.
 
 > **Note**
 > The packages and package versions listed in `requirements.txt` must be

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ requirements.
 For example, a server with only Python 3.9 installed will fail to match content
 that requires Python 3.8.
 
-`rsconnect` will supports detecting Python version requirements in 4 ways:
+`rsconnect` supports detecting Python version requirements in several ways:
     1. A `.python-version` file exists. In such case
        `rsconnect` will use its content to determine the python version requirement.
     2. A `pyproject.toml` with a `project.requires-python` field exists.
@@ -233,11 +233,11 @@ that requires Python 3.8.
        if no `.python-version` file exists.
     3. A `setup.cfg` with an `options.python_requires` field exists.
        In such case the requirement specified in the field will be used
-       if no `.python-version` or `pyproject.toml` files exist.
+       if **1** or **2** were not already satisfied.
     4. If no other source of version requirement was found, then
        the interpreter in use is considered the one required to run the content.
 
-On newer Posit Connect versions the requirement detected by `rsconnect` is
+On Posit Connect `>=2025.03.0` the requirement detected by `rsconnect` is
 always respected. Older Connect versions will instead rely only on the
 python version used to deploy the content to determine the requirement.
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ that requires Python 3.8.
     2. A `pyproject.toml` with a `project.requires-python` field exists.
        In such case the requirement specified in the field will be used
        if no `.python-version` file exists.
-    3. A `setup.cfg` with a `options.python_requirs` field exists.
+    3. A `setup.cfg` with an `options.python_requires` field exists.
        In such case the requirement specified in the field will be used
        if no `.python-version` or `pyproject.toml` files exist.
     4. If no other source of version requirement was found, then

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -372,7 +372,7 @@ def deploy_app(
             )
         )
 
-    _, environment = Environment.create_python_environment(
+    environment = Environment.create_python_environment(
         directory,  # pyright: ignore
         force_generate,
         python,

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -37,7 +37,7 @@ from .bundle import (
     make_quarto_source_bundle,
     read_manifest_file,
 )
-from .environment import Environment, EnvironmentException
+from .environment import Environment
 from .exception import RSConnectException
 from .log import VERBOSE, logger
 from .models import AppMode, AppModes
@@ -78,8 +78,6 @@ def cli_feedback(label: str, stderr: bool = False):
         passed()
     except RSConnectException as exc:
         failed("Error: " + exc.message)
-    except EnvironmentException as exc:
-        failed("Error: " + str(exc))
     except Exception as exc:
         traceback.print_exc()
         failed("Internal error: " + str(exc))

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -31,7 +31,6 @@ import click
 
 from . import api
 from .bundle import (
-    create_python_environment,
     get_default_entrypoint,
     make_api_bundle,
     make_quarto_source_bundle,
@@ -373,7 +372,7 @@ def deploy_app(
             )
         )
 
-    environment = create_python_environment(
+    _, environment = Environment.create_python_environment(
         directory,  # pyright: ignore
         force_generate,
         python,

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -51,7 +51,8 @@ else:
     from typing_extensions import NotRequired, TypedDict
 
 from . import validation
-from .bundle import _default_title, fake_module_file_from_directory
+from .bundle import _default_title
+from .environment import fake_module_file_from_directory
 from .certificates import read_certificate_file
 from .exception import DeploymentFailedException, RSConnectException
 from .http_support import CookieJar, HTTPResponse, HTTPServer, JsonData, append_to_path

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -201,9 +201,7 @@ class Manifest:
                 # If the environment has a python version requirement,
                 # add it to the manifest as environment.python.requires
                 manifest_environment = self.data.setdefault("environment", {})
-                manifest_environment["python"] = {
-                    "requires": environment.python_version_requirement
-                }
+                manifest_environment["python"] = {"requires": environment.python_version_requirement}
 
         if image or env_management_py is not None or env_management_r is not None:
             manifest_environment = self.data.setdefault("environment", {})
@@ -677,9 +675,10 @@ def make_html_manifest(
     filename: str,
 ) -> ManifestData:
     # noinspection SpellCheckingInspection
+    appmode = "static"
     manifest: Manifest(
         metadata=ManifestDataMetadata(
-            appmode="static",
+            appmode=appmode,
             primary_html=filename,
         )
     )
@@ -1723,7 +1722,7 @@ def inspect_environment(
     if "error" in environment_data:
         system_error_message = environment_data.get("error")
         if system_error_message:
-            raise RSConnectException(f"Error creating environment: {system_error_message}") from e
+            raise RSConnectException(f"Error creating environment: {system_error_message}")
 
     try:
         return Environment.from_json(environment_data)
@@ -1731,11 +1730,7 @@ def inspect_environment(
         raise RSConnectException("Error constructing environment object") from e
 
 
-def _get_python_env_info(
-    file_name: str,
-    python: str | None,
-    force_generate: bool = False
-) -> tuple[str, Environment]:
+def _get_python_env_info(file_name: str, python: str | None, force_generate: bool = False) -> tuple[str, Environment]:
     """
     Gathers the python and environment information relating to the specified file
     with an eye to deploy it.

--- a/rsconnect/bundle.py
+++ b/rsconnect/bundle.py
@@ -2306,7 +2306,8 @@ def create_python_environment(
         python_version_requirement = override_python_version
 
     # with cli_feedback("Inspecting Python environment"):
-    _, environment = _get_python_env_info(module_file, python, force_generate, override_python_version)
+    detected_python, environment = _get_python_env_info(module_file, python, force_generate, override_python_version)
+    environment.python = detected_python  # If python is provided, _get_python_env_info will return it as is.
 
     if force_generate:
         _warn_on_ignored_requirements(directory, environment.filename)

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -3,7 +3,7 @@
 Given a directory and a Python executable, this module inspects the environment
 and returns information about the Python version and the environment itself.
 
-To inspect the environment it relies on a subprocess that runs the `rsconnect.subprocesses.environment`
+To inspect the environment it relies on a subprocess that runs the `rsconnect.subprocesses.inspect_environment`
 module. This module is responsible for gathering the environment information and returning it in a JSON format.
 """
 
@@ -19,7 +19,7 @@ import os.path
 from . import pyproject
 from .log import logger
 from .exception import RSConnectException
-from .subprocesses.environment import EnvironmentData, MakeEnvironmentData as _MakeEnvironmentData
+from .subprocesses.inspect_environment import EnvironmentData, MakeEnvironmentData as _MakeEnvironmentData
 
 import click
 
@@ -189,7 +189,7 @@ class Environment:
         if force_generate:
             flags.append("f")
 
-        args = [python, "-m", "rsconnect.subprocesses.environment"]
+        args = [python, "-m", "rsconnect.subprocesses.inspect_environment"]
         if flags:
             args.append("-" + "".join(flags))
         args.append(directory)

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -73,7 +73,7 @@ class Environment:
     @classmethod
     def from_dict(
         cls,
-        data: dict[str, typing.Any],
+        data: typing.Dict[str, typing.Any],
         python_interpreter: typing.Optional[str] = None,
         python_version_requirement: typing.Optional[str] = None,
     ) -> "Environment":

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -25,9 +25,13 @@ import click
 
 
 class Environment:
-    """A project environment,
+    """A Python project environment,
 
-    The data is loaded from a rsconnect.utils.environment json response
+    The data is loaded from a rsconnect.utils.environment json response,
+    the environment contains all the information provided by :class:`EnvironmentData` plus
+    the environment python interpreter and the python interpreter version requirement.
+
+    The goal is to capture all the information needed to replicate such environment.
     """
 
     DATA_FIELDS = {f.name for f in dataclasses.fields(EnvironmentData)}

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -130,7 +130,9 @@ class Environment:
         return environment
 
     @classmethod
-    def _get_python_env_info(cls, file_name: str, python: typing.Optional[str], force_generate: bool = False) -> "Environment":
+    def _get_python_env_info(
+        cls, file_name: str, python: typing.Optional[str], force_generate: bool = False
+    ) -> "Environment":
         """
         Gathers the python and environment information relating to the specified file
         with an eye to deploy it.

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -9,21 +9,21 @@ class Environment:
 
     The data is loaded from a rsconnect.utils.environment json response
     """
+    DATA_FIELDS = dataclasses.fields(EnvironmentData)
 
     def __init__(self, data: EnvironmentData, python_version_requirement: typing.Optional[str] = None):
         self._data = data
-        self._data_fields = dataclasses.fields(self.data)
 
         # Fields that are not loaded from the environment subprocess
-        self.python_version_requirement
+        self.python_version_requirement = python_version_requirement
 
     def __getattr__(self, name: str) -> typing.Any:
         # We directly proxy the attributes of the EnvironmentData object
         # so that schema changes can be handled in EnvironmentData exclusively.
-        return self._data[name]
+        return getattr(self._data, name)
 
     def __setattr__(self, name, value):
-        if name in self._data_fields:
+        if name in self.DATA_FIELDS:
             # proxy the attribute to the underlying EnvironmentData object
             self._data._replace(name=value)
         else:

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -70,6 +70,11 @@ class Environment:
             and self.python_version_requirement == other.python_version_requirement
         )
 
+    def __repr__(self) -> str:
+        data = self._data._asdict()
+        data.pop("contents", None)  # Remove contents as it's too long to display
+        return f"Environment({data}, python_interpreter={self.python_interpreter}, python_version_requirement={self.python_version_requirement})"
+
     @classmethod
     def from_dict(
         cls,

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -73,7 +73,9 @@ class Environment:
     def __repr__(self) -> str:
         data = self._data._asdict()
         data.pop("contents", None)  # Remove contents as it's too long to display
-        return f"Environment({data}, python_interpreter={self.python_interpreter}, python_version_requirement={self.python_version_requirement})"
+        return (f"Environment({data}, "
+                f"python_interpreter={self.python_interpreter}, "
+                f"python_version_requirement={self.python_version_requirement})")
 
     @classmethod
     def from_dict(

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -9,6 +9,7 @@ class Environment:
 
     The data is loaded from a rsconnect.utils.environment json response
     """
+
     DATA_FIELDS = dataclasses.fields(EnvironmentData)
 
     def __init__(self, data: EnvironmentData, python_version_requirement: typing.Optional[str] = None):
@@ -22,7 +23,7 @@ class Environment:
         # so that schema changes can be handled in EnvironmentData exclusively.
         return getattr(self._data, name)
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name: str, value: typing.Any) -> None:
         if name in self.DATA_FIELDS:
             # proxy the attribute to the underlying EnvironmentData object
             self._data._replace(name=value)

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -56,7 +56,7 @@ class Environment:
     def __setattr__(self, name: str, value: typing.Any) -> None:
         if name in self.DATA_FIELDS:
             # proxy the attribute to the underlying EnvironmentData object
-            self._data._replace(name=value)
+            self._data._replace(**{name: value})
         else:
             super().__setattr__(name, value)
 
@@ -130,7 +130,7 @@ class Environment:
         return environment
 
     @classmethod
-    def _get_python_env_info(cls, file_name: str, python: str | None, force_generate: bool = False) -> "Environment":
+    def _get_python_env_info(cls, file_name: str, python: typing.Optional[str], force_generate: bool = False) -> "Environment":
         """
         Gathers the python and environment information relating to the specified file
         with an eye to deploy it.
@@ -227,7 +227,7 @@ def fake_module_file_from_directory(directory: str) -> str:
     return os.path.join(directory, app_name + ".py")
 
 
-def is_environment_dir(directory: str | pathlib.Path) -> bool:
+def is_environment_dir(directory: typing.Union[str, pathlib.Path]) -> bool:
     """Detect whether `directory` is a virtualenv"""
 
     # A virtualenv will have Python at ./bin/python
@@ -237,7 +237,7 @@ def is_environment_dir(directory: str | pathlib.Path) -> bool:
     return os.path.exists(python_path) or os.path.exists(win_path)
 
 
-def list_environment_dirs(directory: str | pathlib.Path) -> list[str]:
+def list_environment_dirs(directory: typing.Union[str, pathlib.Path]) -> list[str]:
     """Returns a list of subdirectories in `directory` that appear to contain virtual environments."""
     envs: list[str] = []
 
@@ -277,7 +277,7 @@ def _warn_if_no_requirements_file(directory: str) -> None:
         )
 
 
-def _warn_if_environment_directory(directory: str | pathlib.Path) -> None:
+def _warn_if_environment_directory(directory: typing.Union[str, pathlib.Path]) -> None:
     """
     Issue a warning if the deployment directory is itself a virtualenv (yikes!).
 

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -73,9 +73,11 @@ class Environment:
     def __repr__(self) -> str:
         data = self._data._asdict()
         data.pop("contents", None)  # Remove contents as it's too long to display
-        return (f"Environment({data}, "
-                f"python_interpreter={self.python_interpreter}, "
-                f"python_version_requirement={self.python_version_requirement})")
+        return (
+            f"Environment({data}, "
+            f"python_interpreter={self.python_interpreter}, "
+            f"python_version_requirement={self.python_version_requirement})"
+        )
 
     @classmethod
     def from_dict(

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -60,6 +60,16 @@ class Environment:
         else:
             super().__setattr__(name, value)
 
+    def __eq__(self, other: typing.Any) -> bool:
+        if not isinstance(other, Environment):
+            return False
+
+        return (
+            self._data == other._data
+            and self.python_interpreter == other.python_interpreter
+            and self.python_version_requirement == other.python_version_requirement
+        )
+
     @classmethod
     def from_dict(
         cls,

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -176,7 +176,7 @@ class Environment:
         Returns a dictionary of information about the environment,
         or containing an "error" field if an error occurred.
         """
-        flags: list[str] = []
+        flags: typing.List[str] = []
         if force_generate:
             flags.append("f")
 
@@ -249,9 +249,9 @@ def is_environment_dir(directory: typing.Union[str, pathlib.Path]) -> bool:
     return os.path.exists(python_path) or os.path.exists(win_path)
 
 
-def list_environment_dirs(directory: typing.Union[str, pathlib.Path]) -> list[str]:
+def list_environment_dirs(directory: typing.Union[str, pathlib.Path]) -> typing.List[str]:
     """Returns a list of subdirectories in `directory` that appear to contain virtual environments."""
-    envs: list[str] = []
+    envs: typing.List[str] = []
 
     for name in os.listdir(directory):
         path = os.path.join(directory, name)

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -53,7 +53,6 @@ from .bundle import (
     create_python_environment,
     default_title_from_manifest,
     fake_module_file_from_directory,
-    get_python_env_info,
     is_environment_dir,
     make_api_bundle,
     make_html_bundle,
@@ -1813,7 +1812,9 @@ def write_manifest_notebook(
             raise RSConnectException("manifest.json already exists. Use --overwrite to overwrite.")
 
     with cli_feedback("Inspecting Python environment"):
-        python, environment = get_python_env_info(file, python, force_generate, override_python_version)
+        environment = create_python_environment(base_dir, force_generate=force_generate, python=python,
+                                                override_python_version=override_python_version,
+                                                app_file=file)
 
     with cli_feedback("Creating manifest.json"):
         environment_file_exists = write_notebook_manifest_json(
@@ -1919,7 +1920,13 @@ def write_manifest_voila(
             raise RSConnectException("manifest.json already exists. Use --overwrite to overwrite.")
 
     with cli_feedback("Inspecting Python environment"):
-        python, environment = get_python_env_info(path, python, force_generate, override_python_version)
+        environment = create_python_environment(
+            base_dir,
+            force_generate=force_generate,
+            override_python_version=override_python_version,
+            python=python,
+            app_file=path,
+        )
 
     environment_file_exists = exists(join(base_dir, environment.filename))
 
@@ -2042,7 +2049,12 @@ def write_manifest_quarto(
     environment = None
     if "jupyter" in engines:
         with cli_feedback("Inspecting Python environment"):
-            python, environment = get_python_env_info(base_dir, python, force_generate, override_python_version)
+            environment = create_python_environment(
+                base_dir,
+                force_generate=force_generate,
+                override_python_version=override_python_version,
+                python=python
+            )
 
         environment_file_exists = exists(join(base_dir, environment.filename))
         if environment_file_exists and not force_generate:
@@ -2285,7 +2297,12 @@ def _write_framework_manifest(
             raise RSConnectException("manifest.json already exists. Use --overwrite to overwrite.")
 
     with cli_feedback("Inspecting Python environment"):
-        _, environment = get_python_env_info(directory, python, force_generate, override_python_version)
+        environment = create_python_environment(
+            directory,
+            force_generate=force_generate,
+            override_python_version=override_python_version,
+            python=python,
+        )
 
     if app_mode == AppModes.PYTHON_SHINY:
         with cli_feedback("Inspecting Shiny for Python app"):

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -913,7 +913,7 @@ def deploy_notebook(
     app_mode = AppModes.JUPYTER_NOTEBOOK if not static else AppModes.STATIC
 
     base_dir = dirname(file)
-    python, environment = Environment.create_python_environment(
+    environment = Environment.create_python_environment(
         base_dir,
         app_file=file,
         force_generate=force_generate,
@@ -944,7 +944,7 @@ def deploy_notebook(
         ce.make_bundle(
             make_notebook_html_bundle,
             file,
-            python,
+            environment.python,
             hide_all_input,
             hide_tagged_input,
         )
@@ -1054,7 +1054,7 @@ def deploy_voila(
     set_verbosity(verbose)
     output_params(ctx, locals().items())
     app_mode = AppModes.JUPYTER_VOILA
-    _, environment = Environment.create_python_environment(
+    environment = Environment.create_python_environment(
         path if isdir(path) else dirname(path), force_generate, python, override_python_version
     )
 
@@ -1271,7 +1271,7 @@ def deploy_quarto(
     environment = None
     if "jupyter" in engines:
         with cli_feedback("Inspecting Python environment"):
-            _, environment = Environment.create_python_environment(
+            environment = Environment.create_python_environment(
                 base_dir, force_generate=force_generate, override_python_version=override_python_version
             )
 
@@ -1614,7 +1614,7 @@ def generate_deploy_python(app_mode: AppMode, alias: str, min_version: str, desc
         set_verbosity(verbose)
         entrypoint = validate_entry_point(entrypoint, directory)
         extra_files_list = validate_extra_files(directory, extra_files)
-        _, environment = Environment.create_python_environment(
+        environment = Environment.create_python_environment(
             directory, force_generate, python, override_python_version=override_python_version
         )
 
@@ -1785,7 +1785,7 @@ def write_manifest_notebook(
             raise RSConnectException("manifest.json already exists. Use --overwrite to overwrite.")
 
     with cli_feedback("Inspecting Python environment"):
-        _, environment = Environment.create_python_environment(
+        environment = Environment.create_python_environment(
             base_dir,
             force_generate=force_generate,
             python=python,
@@ -1897,7 +1897,7 @@ def write_manifest_voila(
             raise RSConnectException("manifest.json already exists. Use --overwrite to overwrite.")
 
     with cli_feedback("Inspecting Python environment"):
-        _, environment = Environment.create_python_environment(
+        environment = Environment.create_python_environment(
             base_dir,
             force_generate=force_generate,
             override_python_version=override_python_version,
@@ -2026,7 +2026,7 @@ def write_manifest_quarto(
     environment = None
     if "jupyter" in engines:
         with cli_feedback("Inspecting Python environment"):
-            _, environment = Environment.create_python_environment(
+            environment = Environment.create_python_environment(
                 base_dir, force_generate=force_generate, override_python_version=override_python_version, python=python
             )
 
@@ -2271,7 +2271,7 @@ def _write_framework_manifest(
             raise RSConnectException("manifest.json already exists. Use --overwrite to overwrite.")
 
     with cli_feedback("Inspecting Python environment"):
-        _, environment = Environment.create_python_environment(
+        environment = Environment.create_python_environment(
             directory,
             force_generate=force_generate,
             override_python_version=override_python_version,

--- a/rsconnect/main.py
+++ b/rsconnect/main.py
@@ -48,11 +48,10 @@ from .actions_content import (
     get_content,
     search_content,
 )
+from .environment import Environment, fake_module_file_from_directory
 from .api import RSConnectClient, RSConnectExecutor, RSConnectServer
 from .bundle import (
-    create_python_environment,
     default_title_from_manifest,
-    fake_module_file_from_directory,
     make_api_bundle,
     make_html_bundle,
     make_manifest_bundle,
@@ -914,7 +913,7 @@ def deploy_notebook(
     app_mode = AppModes.JUPYTER_NOTEBOOK if not static else AppModes.STATIC
 
     base_dir = dirname(file)
-    environment = create_python_environment(
+    python, environment = Environment.create_python_environment(
         base_dir,
         app_file=file,
         force_generate=force_generate,
@@ -1055,7 +1054,7 @@ def deploy_voila(
     set_verbosity(verbose)
     output_params(ctx, locals().items())
     app_mode = AppModes.JUPYTER_VOILA
-    environment = create_python_environment(
+    _, environment = Environment.create_python_environment(
         path if isdir(path) else dirname(path), force_generate, python, override_python_version
     )
 
@@ -1272,7 +1271,7 @@ def deploy_quarto(
     environment = None
     if "jupyter" in engines:
         with cli_feedback("Inspecting Python environment"):
-            environment = create_python_environment(
+            _, environment = Environment.create_python_environment(
                 base_dir, force_generate=force_generate, override_python_version=override_python_version
             )
 
@@ -1615,7 +1614,7 @@ def generate_deploy_python(app_mode: AppMode, alias: str, min_version: str, desc
         set_verbosity(verbose)
         entrypoint = validate_entry_point(entrypoint, directory)
         extra_files_list = validate_extra_files(directory, extra_files)
-        environment = create_python_environment(
+        _, environment = Environment.create_python_environment(
             directory, force_generate, python, override_python_version=override_python_version
         )
 
@@ -1786,7 +1785,7 @@ def write_manifest_notebook(
             raise RSConnectException("manifest.json already exists. Use --overwrite to overwrite.")
 
     with cli_feedback("Inspecting Python environment"):
-        environment = create_python_environment(
+        _, environment = Environment.create_python_environment(
             base_dir,
             force_generate=force_generate,
             python=python,
@@ -1898,7 +1897,7 @@ def write_manifest_voila(
             raise RSConnectException("manifest.json already exists. Use --overwrite to overwrite.")
 
     with cli_feedback("Inspecting Python environment"):
-        environment = create_python_environment(
+        _, environment = Environment.create_python_environment(
             base_dir,
             force_generate=force_generate,
             override_python_version=override_python_version,
@@ -2027,7 +2026,7 @@ def write_manifest_quarto(
     environment = None
     if "jupyter" in engines:
         with cli_feedback("Inspecting Python environment"):
-            environment = create_python_environment(
+            _, environment = Environment.create_python_environment(
                 base_dir, force_generate=force_generate, override_python_version=override_python_version, python=python
             )
 
@@ -2272,7 +2271,7 @@ def _write_framework_manifest(
             raise RSConnectException("manifest.json already exists. Use --overwrite to overwrite.")
 
     with cli_feedback("Inspecting Python environment"):
-        environment = create_python_environment(
+        _, environment = Environment.create_python_environment(
             directory,
             force_generate=force_generate,
             override_python_version=override_python_version,

--- a/rsconnect/pyproject.py
+++ b/rsconnect/pyproject.py
@@ -55,7 +55,7 @@ def lookup_metadata_file(directory: typing.Union[str, pathlib.Path]) -> typing.L
 
 def get_python_version_requirement_parser(
     metadata_file: pathlib.Path,
-) -> typing.Optional[typing.Callable[[pathlib.Path], typing.Optional[str]]]:
+) -> typing.Callable[[pathlib.Path], typing.Optional[str]]:
     """Given the metadata file, return the appropriate parser function.
 
     The returned function takes a pathlib.Path and returns the parsed value.

--- a/rsconnect/pyproject.py
+++ b/rsconnect/pyproject.py
@@ -16,6 +16,23 @@ except ImportError:
     import toml as tomllib  # type: ignore[no-redef]
 
 
+def detect_python_version_requirement(directory: typing.Union[str, pathlib.Path]) -> typing.Optional[str]:
+    """Detect the python version requirement for a project.
+
+    The directory should contain a metadata file such as pyproject.toml,
+    setup.cfg, or .python-version.
+
+    Returns the python version requirement as a string or None if not found.
+    """
+    for _, metadata_file in lookup_metadata_file(directory):
+        parser = get_python_version_requirement_parser(metadata_file)
+        version_constraint = parser(metadata_file)
+        if version_constraint:
+            return version_constraint
+
+    return None
+
+
 def lookup_metadata_file(directory: typing.Union[str, pathlib.Path]) -> typing.List[typing.Tuple[str, pathlib.Path]]:
     """Given the directory of a project return the path of a usable metadata file.
 
@@ -50,7 +67,7 @@ def get_python_version_requirement_parser(
     elif metadata_file.name == ".python-version":
         return parse_pyversion_python_requires
     else:
-        return None
+        raise NotImplementedError(f"Unknown metadata file type: {metadata_file.name}")
 
 
 def parse_pyproject_python_requires(pyproject_file: pathlib.Path) -> typing.Optional[str]:

--- a/rsconnect/subprocesses/environment.py
+++ b/rsconnect/subprocesses/environment.py
@@ -53,7 +53,7 @@ def MakeEnvironmentData(
     error: Optional[str] = None,
     **kwargs: object,  # provides compatibility where we no longer support some older properties
 ) -> Environment:
-    return Environment(contents, filename, locale, package_manager, pip, python, source, python_requires, error)
+    return EnvironmentData(contents, filename, locale, package_manager, pip, python, source, python_requires, error)
 
 
 class EnvironmentException(Exception):

--- a/rsconnect/subprocesses/environment.py
+++ b/rsconnect/subprocesses/environment.py
@@ -3,7 +3,7 @@
 Environment data class abstraction that is usable as an executable module
 
 ```bash
-python -m rsconnect.utils.environment
+python -m rsconnect.subprocesses.environment
 ```
 """
 from __future__ import annotations

--- a/rsconnect/subprocesses/environment.py
+++ b/rsconnect/subprocesses/environment.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python
+"""
+Environment data class abstraction that is usable as an executable module
+
+```bash
+python -m rsconnect.utils.environment
+```
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import locale
+import os
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, replace
+from typing import Callable, Optional
+
+version_re = re.compile(r"\d+\.\d+(\.\d+)?")
+exec_dir = os.path.dirname(sys.executable)
+
+
+@dataclass(frozen=True)
+class EnvironmentData:
+    contents: str
+    filename: str
+    locale: str
+    package_manager: str
+    pip: str
+    python: str
+    source: str
+    python_requires: Optional[str]
+    error: Optional[str]
+
+    def _asdict(self):
+        return asdict(self)
+
+    def _replace(self, **kwargs: object):
+        return replace(self, **kwargs)
+
+
+def MakeEnvironmentData(
+    contents: str,
+    filename: str,
+    locale: str,
+    package_manager: str,
+    pip: str,
+    python: str,
+    source: str,
+    python_requires: Optional[str] = None,
+    error: Optional[str] = None,
+    **kwargs: object,  # provides compatibility where we no longer support some older properties
+) -> Environment:
+    return Environment(contents, filename, locale, package_manager, pip, python, source, python_requires, error)
+
+
+class EnvironmentException(Exception):
+    pass
+
+
+def detect_environment(dirname: str, force_generate: bool = False) -> EnvironmentData:
+    """Determine the python dependencies in the environment.
+
+    `pip freeze` will be used to introspect the environment.
+
+    :param: dirname Directory name
+    :param: force_generate Force the generation of an environment
+    :return: a dictionary containing the package spec filename and contents if successful,
+    or a dictionary containing `error` on failure.
+    """
+
+    if force_generate:
+        result = pip_freeze()
+    else:
+        result = output_file(dirname, "requirements.txt", "pip") or pip_freeze()
+
+    if result is not None:
+        result["python"] = get_python_version()
+        result["pip"] = get_version("pip")
+        result["locale"] = get_default_locale()
+
+    return MakeEnvironmentData(**result)
+
+
+def get_python_version() -> str:
+    v = sys.version_info
+    return "%d.%d.%d" % (v[0], v[1], v[2])
+
+
+def get_default_locale(locale_source: Callable[..., tuple[str | None, str | None]] = locale.getlocale):
+    result = ".".join([item or "" for item in locale_source()])
+    return "" if result == "." else result
+
+
+def get_version(module: str):
+    try:
+        args = [sys.executable, "-m", module, "--version"]
+        proc = subprocess.Popen(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+        stdout, _stderr = proc.communicate()
+        match = version_re.search(stdout)
+        if match:
+            return match.group()
+
+        msg = "Failed to get version of '%s' from the output of: %s" % (
+            module,
+            " ".join(args),
+        )
+        raise EnvironmentException(msg)
+    except Exception as exception:
+        raise EnvironmentException("Error getting '%s' version: %s" % (module, str(exception)))
+
+
+def output_file(dirname: str, filename: str, package_manager: str):
+    """Read an existing package spec file.
+
+    Returns a dictionary containing the filename and contents
+    if successful, None if the file does not exist,
+    or a dictionary containing 'error' on failure.
+    """
+    try:
+        path = os.path.join(dirname, filename)
+        if not os.path.exists(path):
+            return None
+
+        with open(path, "r") as f:
+            data = f.read()
+
+        data = "\n".join([line for line in data.split("\n") if "rsconnect" not in line])
+
+        return {
+            "filename": filename,
+            "contents": data,
+            "source": "file",
+            "package_manager": package_manager,
+        }
+    except Exception as exception:
+        raise EnvironmentException("Error reading %s: %s" % (filename, str(exception)))
+
+
+def pip_freeze():
+    """Inspect the environment using `pip freeze --disable-pip-version-check version`.
+
+    Returns a dictionary containing the filename
+    (always 'requirements.txt') and contents if successful,
+    or a dictionary containing 'error' on failure.
+    """
+    try:
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "pip", "freeze", "--disable-pip-version-check"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+
+        pip_stdout, pip_stderr = proc.communicate()
+        pip_status = proc.returncode
+    except Exception as exception:
+        raise EnvironmentException("Error during pip freeze: %s" % str(exception))
+
+    if pip_status != 0:
+        msg = pip_stderr or ("exited with code %d" % pip_status)
+        raise EnvironmentException("Error during pip freeze: %s" % msg)
+
+    pip_stdout = filter_pip_freeze_output(pip_stdout)
+
+    pip_stdout = (
+        "# requirements.txt generated by rsconnect-python on "
+        + str(datetime.datetime.now(datetime.timezone.utc))
+        + "\n"
+        + pip_stdout
+    )
+
+    return {
+        "filename": "requirements.txt",
+        "contents": pip_stdout,
+        "source": "pip_freeze",
+        "package_manager": "pip",
+    }
+
+
+def filter_pip_freeze_output(pip_stdout: str):
+    # Filter out dependency on `rsconnect` and ignore output lines from pip which start with `[notice]`
+    return "\n".join(
+        [line for line in pip_stdout.split("\n") if (("rsconnect" not in line) and (line.find("[notice]") != 0))]
+    )
+
+
+def strip_ref(line: str):
+    # remove erroneous conda build paths that will break pip install
+    return line.split(" @ file:", 1)[0].strip()
+
+
+def exclude(line: str):
+    return line and line.startswith("setuptools") and "post" in line
+
+
+def main():
+    """
+    Run `detect_environment` and dump the result as JSON.
+    """
+    try:
+        if len(sys.argv) < 2:
+            raise EnvironmentException("Usage: %s [-fc] DIRECTORY" % sys.argv[0])
+        # directory is always the last argument
+        directory = sys.argv[len(sys.argv) - 1]
+        flags = ""
+        force_generate = False
+        if len(sys.argv) > 2:
+            flags = sys.argv[1]
+        if "f" in flags:
+            force_generate = True
+        envinfo = detect_environment(directory, force_generate)._asdict()
+        if "contents" in envinfo:
+            keepers = list(map(strip_ref, envinfo["contents"].split("\n")))
+            keepers = [line for line in keepers if not exclude(line)]
+            envinfo["contents"] = "\n".join(keepers)
+
+        json.dump(
+            envinfo,
+            sys.stdout,
+            indent=4,
+        )
+    except EnvironmentException as exception:
+        json.dump(dict(error=str(exception)), sys.stdout, indent=4)
+
+
+if __name__ == "__main__":
+    main()

--- a/rsconnect/subprocesses/environment.py
+++ b/rsconnect/subprocesses/environment.py
@@ -52,7 +52,7 @@ def MakeEnvironmentData(
     python_requires: Optional[str] = None,
     error: Optional[str] = None,
     **kwargs: object,  # provides compatibility where we no longer support some older properties
-) -> Environment:
+) -> EnvironmentData:
     return EnvironmentData(contents, filename, locale, package_manager, pip, python, source, python_requires, error)
 
 

--- a/rsconnect/subprocesses/inspect_environment.py
+++ b/rsconnect/subprocesses/inspect_environment.py
@@ -3,7 +3,7 @@
 Environment data class abstraction that is usable as an executable module
 
 ```bash
-python -m rsconnect.subprocesses.environment
+python -m rsconnect.subprocesses.inspect_environment
 ```
 """
 from __future__ import annotations

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -11,17 +11,13 @@ from unittest import TestCase, mock
 
 import pytest
 
-import rsconnect.bundle
 from rsconnect.bundle import (
     Manifest,
     _default_title,
     _default_title_from_manifest,
     create_html_manifest,
-    create_python_environment,
     create_voila_manifest,
-    _get_python_env_info,
     guess_deploy_dir,
-    inspect_environment,
     keep_manifest_specified_file,
     list_files,
     make_api_bundle,
@@ -40,9 +36,8 @@ from rsconnect.bundle import (
     to_bytes,
     validate_entry_point,
     validate_extra_files,
-    which_python,
 )
-from rsconnect.environment import Environment, MakeEnvironment, detect_environment
+from rsconnect.environment import Environment
 from rsconnect.exception import RSConnectException
 from rsconnect.models import AppModes
 
@@ -85,7 +80,7 @@ class TestBundle(TestCase):
         # the test environment. Don't do this in the production code, which
         # runs in the notebook server. We need the introspection to run in
         # the kernel environment and not the notebook server environment.
-        environment = detect_environment(directory)
+        environment = Environment.create_python_environment(directory)
         with make_notebook_source_bundle(
             nb_path,
             environment,
@@ -155,7 +150,7 @@ class TestBundle(TestCase):
         # the test environment. Don't do this in the production code, which
         # runs in the notebook server. We need the introspection to run in
         # the kernel environment and not the notebook server environment.
-        environment = detect_environment(directory)
+        environment = Environment.create_python_environment(directory)
 
         with make_notebook_source_bundle(
             nb_path,
@@ -255,7 +250,7 @@ class TestBundle(TestCase):
         # input file.
         create_fake_quarto_rendered_output(temp_proj, "myquarto")
 
-        environment = detect_environment(temp_proj)
+        environment = Environment.create_python_environment(temp_proj)
 
         # mock the result of running of `quarto inspect <project_dir>`
         inspect = {
@@ -352,7 +347,7 @@ class TestBundle(TestCase):
         create_fake_quarto_rendered_output(site_dir, "index")
         create_fake_quarto_rendered_output(site_dir, "about")
 
-        environment = detect_environment(temp_proj)
+        environment = Environment.create_python_environment(temp_proj)
 
         # mock the result of running of `quarto inspect <project_dir>`
         inspect = {
@@ -454,7 +449,7 @@ class TestBundle(TestCase):
         fp.write("pandas\n")
         fp.close()
 
-        environment = detect_environment(temp_proj)
+        environment = Environment.create_python_environment(temp_proj)
 
         # mock the result of running of `quarto inspect <project_dir>`
         inspect = {
@@ -743,7 +738,7 @@ class TestBundle(TestCase):
         # include environment parameter
         manifest = make_source_manifest(
             AppModes.PYTHON_API,
-            Environment(
+            Environment.from_dict(dict(
                 contents="",
                 error=None,
                 filename="requirements.txt",
@@ -752,7 +747,7 @@ class TestBundle(TestCase):
                 pip="22.0.4",
                 python="3.9.12",
                 source="file",
-            ),
+            )),
             None,
             None,
             None,
@@ -922,7 +917,7 @@ class TestBundle(TestCase):
                 "config": {"project": {"title": "quarto-proj-py"}, "editor": "visual", "language": {}},
             },
             AppModes.SHINY_QUARTO,
-            Environment(
+            Environment.from_dict(dict(
                 contents="",
                 error=None,
                 filename="requirements.txt",
@@ -931,7 +926,7 @@ class TestBundle(TestCase):
                 pip="22.0.4",
                 python="3.9.12",
                 source="file",
-            ),
+            )),
             [],
             [],
             None,
@@ -1207,132 +1202,6 @@ class TestBundle(TestCase):
         m = {"metadata": {"entrypoint": "module:object"}}
         self.assertEqual(_default_title_from_manifest(m, "dir/to/manifest.json"), "0to")
 
-    def test_inspect_environment(self):
-        environment = inspect_environment(sys.executable, get_dir("pip1"))
-        assert environment is not None
-        assert environment.python != ""
-
-    def test_inspect_environment_catches_type_error(self):
-        with pytest.raises(RSConnectException) as exec_info:
-            inspect_environment(sys.executable, None)  # type: ignore
-
-        assert isinstance(exec_info.value, RSConnectException)
-        assert isinstance(exec_info.value.__cause__, TypeError)
-
-
-@pytest.mark.parametrize(
-    (
-        "file_name",
-        "python",
-        "force_generate",
-        "expected_python",
-        "expected_environment",
-    ),
-    [
-        pytest.param(
-            "path/to/file.py",
-            sys.executable,
-            False,
-            sys.executable,
-            MakeEnvironment(
-                contents=None,
-                filename="requirements.txt",
-                locale="en_US.UTF-8",
-                package_manager="pip",
-                pip=None,
-                python=None,
-                source="pip_freeze",
-                error=None,
-            ),
-            id="basic",
-        ),
-        pytest.param(
-            "another/file.py",
-            basename(sys.executable),
-            False,
-            sys.executable,
-            MakeEnvironment(
-                contents=None,
-                filename="requirements.txt",
-                locale="en_US.UTF-8",
-                package_manager="pip",
-                pip=None,
-                python=None,
-                source="pip_freeze",
-                error=None,
-            ),
-            id="which_python",
-        ),
-        pytest.param(
-            "will/the/files/never/stop.py",
-            "argh.py",
-            False,
-            "unused",
-            MakeEnvironment(None, None, None, None, None, None, None, error="Could not even do things"),
-            id="exploding",
-        ),
-    ],
-)
-def test_get_python_env_info(
-    monkeypatch,
-    file_name,
-    python,
-    force_generate,
-    expected_python,
-    expected_environment,
-):
-    def fake_which_python(python, env=os.environ):
-        return expected_python
-
-    def fake_inspect_environment(
-        python,
-        directory,
-        force_generate=False,
-        check_output=subprocess.check_output,
-    ):
-        return expected_environment
-
-    monkeypatch.setattr(rsconnect.bundle, "inspect_environment", fake_inspect_environment)
-
-    monkeypatch.setattr(rsconnect.bundle, "which_python", fake_which_python)
-
-    if expected_environment.error is not None:
-        with pytest.raises(RSConnectException):
-            _, _ = _get_python_env_info(file_name, python, force_generate=force_generate)
-    else:
-        python, environment = _get_python_env_info(file_name, python, force_generate=force_generate)
-
-        assert python == expected_python
-        assert environment == expected_environment
-
-
-class WhichPythonTestCase(TestCase):
-    def test_default(self):
-        self.assertEqual(which_python(), sys.executable)
-
-    def test_none(self):
-        self.assertEqual(which_python(None), sys.executable)
-
-    def test_sys(self):
-        self.assertEqual(which_python(sys.executable), sys.executable)
-
-    def test_does_not_exist(self):
-        with tempfile.NamedTemporaryFile() as tmpfile:
-            name = tmpfile.name
-        with self.assertRaises(RSConnectException):
-            which_python(name)
-
-    def test_is_directory(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with self.assertRaises(RSConnectException):
-                which_python(tmpdir)
-
-    @pytest.mark.skipif(sys.platform.startswith("win"), reason="os.X_OK always returns True")
-    def test_is_not_executable(self):
-        with tempfile.NamedTemporaryFile() as tmpfile:
-            with self.assertRaises(RSConnectException):
-                which_python(tmpfile.name)
-
 
 cur_dir = os.path.dirname(__file__)
 bqplot_dir = os.path.join(cur_dir, "testdata", "voila", "bqplot", "")
@@ -1396,7 +1265,7 @@ class Test_guess_deploy_dir(TestCase):
     ],
 )
 def test_create_voila_manifest_1(path, entrypoint):
-    environment = Environment(
+    environment = Environment.from_dict(dict(
         contents="bqplot\n",
         error=None,
         filename="requirements.txt",
@@ -1405,7 +1274,7 @@ def test_create_voila_manifest_1(path, entrypoint):
         pip="23.0",
         python="3.8.12",
         source="file",
-    )
+    ))
 
     if sys.platform == "win32":
         checksum_hash = "b7ba4ec7b6721c86ab883f5e6e2ea68f"
@@ -1469,7 +1338,7 @@ def test_create_voila_manifest_1(path, entrypoint):
     ],
 )
 def test_create_voila_manifest_2(path, entrypoint):
-    environment = Environment(
+    environment = Environment.from_dict(dict(
         contents="numpy\nipywidgets\nbqplot\n",
         error=None,
         filename="requirements.txt",
@@ -1478,7 +1347,7 @@ def test_create_voila_manifest_2(path, entrypoint):
         pip="23.0",
         python="3.8.12",
         source="file",
-    )
+    ))
 
     if sys.platform == "win32":
         bqplot_hash = "b7ba4ec7b6721c86ab883f5e6e2ea68f"
@@ -1515,7 +1384,7 @@ def test_create_voila_manifest_2(path, entrypoint):
 
 
 def test_create_voila_manifest_extra():
-    environment = Environment(
+    environment = Environment.from_dict(dict(
         contents="numpy\nipywidgets\nbqplot\n",
         error=None,
         filename="requirements.txt",
@@ -1524,7 +1393,7 @@ def test_create_voila_manifest_extra():
         pip="23.0.1",
         python="3.8.12",
         source="file",
-    )
+    ))
 
     if sys.platform == "win32":
         requirements_checksum = "d51994456975ff487749acc247ae6d63"
@@ -1599,7 +1468,7 @@ def test_create_voila_manifest_extra():
     ],
 )
 def test_create_voila_manifest_multi_notebook(path, entrypoint):
-    environment = Environment(
+    environment = Environment.from_dict(dict(
         contents="bqplot\n",
         error=None,
         filename="requirements.txt",
@@ -1608,7 +1477,7 @@ def test_create_voila_manifest_multi_notebook(path, entrypoint):
         pip="23.0",
         python="3.8.12",
         source="file",
-    )
+    ))
 
     if sys.platform == "win32":
         bqplot_hash = "ddb4070466d3c45b2f233dd39906ddf6"
@@ -1704,7 +1573,7 @@ def test_make_voila_bundle(
     path,
     entrypoint,
 ):
-    environment = Environment(
+    environment = Environment.from_dict(dict(
         contents="bqplot",
         error=None,
         filename="requirements.txt",
@@ -1713,7 +1582,7 @@ def test_make_voila_bundle(
         pip="23.0",
         python="3.8.12",
         source="file",
-    )
+    ))
 
     if sys.platform == "win32":
         checksum_hash = "b7ba4ec7b6721c86ab883f5e6e2ea68f"
@@ -1811,7 +1680,7 @@ def test_make_voila_bundle_multi_notebook(
     path,
     entrypoint,
 ):
-    environment = Environment(
+    environment = Environment.from_dict(dict(
         contents="bqplot",
         error=None,
         filename="requirements.txt",
@@ -1820,7 +1689,7 @@ def test_make_voila_bundle_multi_notebook(
         pip="23.0",
         python="3.8.12",
         source="file",
-    )
+    ))
 
     if sys.platform == "win32":
         bqplot_hash = "ddb4070466d3c45b2f233dd39906ddf6"
@@ -1900,7 +1769,7 @@ def test_make_voila_bundle_2(
     path,
     entrypoint,
 ):
-    environment = Environment(
+    environment = Environment.from_dict(dict(
         contents="numpy\nipywidgets\nbqplot\n",
         error=None,
         filename="requirements.txt",
@@ -1909,7 +1778,7 @@ def test_make_voila_bundle_2(
         pip="23.0",
         python="3.8.12",
         source="file",
-    )
+    ))
 
     if sys.platform == "win32":
         bqplot_hash = "b7ba4ec7b6721c86ab883f5e6e2ea68f"
@@ -1964,7 +1833,7 @@ def test_make_voila_bundle_extra():
 
     requirements_hash = "d51994456975ff487749acc247ae6d63"
 
-    environment = Environment(
+    environment = Environment.from_dict(dict(
         contents="numpy\nipywidgets\nbqplot\n",
         error=None,
         filename="requirements.txt",
@@ -1973,7 +1842,7 @@ def test_make_voila_bundle_extra():
         pip="23.0.1",
         python="3.8.12",
         source="file",
-    )
+    ))
     ans = {
         "version": 1,
         "locale": "en_US.UTF-8",
@@ -2437,7 +2306,7 @@ def test_make_api_manifest_fastapi():
             "prices.csv": {"checksum": "012afa636c426748177b38160135307a"},
         },
     }
-    environment = create_python_environment(
+    environment = Environment.create_python_environment(
         fastapi_dir,
     )
     manifest, _ = make_api_manifest(
@@ -2469,7 +2338,7 @@ def test_make_api_bundle_fastapi():
             "prices.csv": {"checksum": "012afa636c426748177b38160135307a"},
         },
     }
-    environment = create_python_environment(
+    environment = Environment.create_python_environment(
         fastapi_dir,
     )
     with make_api_bundle(
@@ -2513,7 +2382,7 @@ def test_make_api_manifest_flask():
             "prices.csv": {"checksum": "012afa636c426748177b38160135307a"},
         },
     }
-    environment = create_python_environment(
+    environment = Environment.create_python_environment(
         flask_dir,
     )
     manifest, _ = make_api_manifest(
@@ -2545,7 +2414,7 @@ def test_make_api_bundle_flask():
             "prices.csv": {"checksum": "012afa636c426748177b38160135307a"},
         },
     }
-    environment = create_python_environment(
+    environment = Environment.create_python_environment(
         flask_dir,
     )
     with make_api_bundle(
@@ -2589,7 +2458,7 @@ def test_make_api_manifest_streamlit():
             "data.csv": {"checksum": "aabd9d1210246c69403532a6a9d24286"},
         },
     }
-    environment = create_python_environment(
+    environment = Environment.create_python_environment(
         streamlit_dir,
     )
     manifest, _ = make_api_manifest(
@@ -2620,7 +2489,7 @@ def test_make_api_bundle_streamlit():
             "data.csv": {"checksum": "aabd9d1210246c69403532a6a9d24286"},
         },
     }
-    environment = create_python_environment(
+    environment = Environment.create_python_environment(
         streamlit_dir,
     )
     with make_api_bundle(
@@ -2665,7 +2534,7 @@ def test_make_api_manifest_dash():
             "prices.csv": {"checksum": "3efb0ed7ad93bede9dc88f7a81ad4153"},
         },
     }
-    environment = create_python_environment(
+    environment = Environment.create_python_environment(
         dash_dir,
     )
     manifest, _ = make_api_manifest(
@@ -2697,7 +2566,7 @@ def test_make_api_bundle_dash():
             "prices.csv": {"checksum": "3efb0ed7ad93bede9dc88f7a81ad4153"},
         },
     }
-    environment = create_python_environment(
+    environment = Environment.create_python_environment(
         dash_dir,
     )
     with make_api_bundle(
@@ -2741,7 +2610,7 @@ def test_make_api_manifest_bokeh():
             "data.csv": {"checksum": "aabd9d1210246c69403532a6a9d24286"},
         },
     }
-    environment = create_python_environment(
+    environment = Environment.create_python_environment(
         bokeh_dir,
     )
     manifest, _ = make_api_manifest(
@@ -2774,7 +2643,7 @@ def test_make_api_bundle_bokeh():
         },
     }
 
-    environment = create_python_environment(
+    environment = Environment.create_python_environment(
         bokeh_dir,
     )
     with make_api_bundle(
@@ -2818,7 +2687,7 @@ def test_make_api_manifest_shiny():
             "data.csv": {"checksum": "aabd9d1210246c69403532a6a9d24286"},
         },
     }
-    environment = create_python_environment(
+    environment = Environment.create_python_environment(
         shiny_dir,
     )
     manifest, _ = make_api_manifest(
@@ -2850,7 +2719,7 @@ def test_make_api_bundle_shiny():
             "data.csv": {"checksum": "aabd9d1210246c69403532a6a9d24286"},
         },
     }
-    environment = create_python_environment(
+    environment = Environment.create_python_environment(
         shiny_dir,
     )
     with make_api_bundle(
@@ -2928,7 +2797,7 @@ def test_make_api_manifest_gradio():
             "app.py": {"checksum": "22feec76e9c02ac6b5a34a083e2983b6"},
         },
     }
-    environment = create_python_environment(
+    environment = Environment.create_python_environment(
         gradio_dir,
     )
     manifest, _ = make_api_manifest(
@@ -2958,7 +2827,7 @@ def test_make_api_bundle_gradio():
             "app.py": {"checksum": "22feec76e9c02ac6b5a34a083e2983b6"},
         },
     }
-    environment = create_python_environment(
+    environment = Environment.create_python_environment(
         gradio_dir,
     )
     with make_api_bundle(

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -19,7 +19,7 @@ from rsconnect.bundle import (
     create_html_manifest,
     create_python_environment,
     create_voila_manifest,
-    get_python_env_info,
+    _get_python_env_info,
     guess_deploy_dir,
     inspect_environment,
     keep_manifest_specified_file,
@@ -1298,9 +1298,9 @@ def test_get_python_env_info(
 
     if expected_environment.error is not None:
         with pytest.raises(RSConnectException):
-            _, _ = get_python_env_info(file_name, python, force_generate=force_generate)
+            _, _ = _get_python_env_info(file_name, python, force_generate=force_generate)
     else:
-        python, environment = get_python_env_info(file_name, python, force_generate=force_generate)
+        python, environment = _get_python_env_info(file_name, python, force_generate=force_generate)
 
         assert python == expected_python
         assert environment == expected_environment

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
 import os
-import subprocess
 import sys
 import tarfile
 import tempfile
@@ -738,16 +737,18 @@ class TestBundle(TestCase):
         # include environment parameter
         manifest = make_source_manifest(
             AppModes.PYTHON_API,
-            Environment.from_dict(dict(
-                contents="",
-                error=None,
-                filename="requirements.txt",
-                locale="en_US.UTF-8",
-                package_manager="pip",
-                pip="22.0.4",
-                python="3.9.12",
-                source="file",
-            )),
+            Environment.from_dict(
+                dict(
+                    contents="",
+                    error=None,
+                    filename="requirements.txt",
+                    locale="en_US.UTF-8",
+                    package_manager="pip",
+                    pip="22.0.4",
+                    python="3.9.12",
+                    source="file",
+                )
+            ),
             None,
             None,
             None,
@@ -917,16 +918,18 @@ class TestBundle(TestCase):
                 "config": {"project": {"title": "quarto-proj-py"}, "editor": "visual", "language": {}},
             },
             AppModes.SHINY_QUARTO,
-            Environment.from_dict(dict(
-                contents="",
-                error=None,
-                filename="requirements.txt",
-                locale="en_US.UTF-8",
-                package_manager="pip",
-                pip="22.0.4",
-                python="3.9.12",
-                source="file",
-            )),
+            Environment.from_dict(
+                dict(
+                    contents="",
+                    error=None,
+                    filename="requirements.txt",
+                    locale="en_US.UTF-8",
+                    package_manager="pip",
+                    pip="22.0.4",
+                    python="3.9.12",
+                    source="file",
+                )
+            ),
             [],
             [],
             None,
@@ -1265,16 +1268,18 @@ class Test_guess_deploy_dir(TestCase):
     ],
 )
 def test_create_voila_manifest_1(path, entrypoint):
-    environment = Environment.from_dict(dict(
-        contents="bqplot\n",
-        error=None,
-        filename="requirements.txt",
-        locale="en_US.UTF-8",
-        package_manager="pip",
-        pip="23.0",
-        python="3.8.12",
-        source="file",
-    ))
+    environment = Environment.from_dict(
+        dict(
+            contents="bqplot\n",
+            error=None,
+            filename="requirements.txt",
+            locale="en_US.UTF-8",
+            package_manager="pip",
+            pip="23.0",
+            python="3.8.12",
+            source="file",
+        )
+    )
 
     if sys.platform == "win32":
         checksum_hash = "b7ba4ec7b6721c86ab883f5e6e2ea68f"
@@ -1338,16 +1343,18 @@ def test_create_voila_manifest_1(path, entrypoint):
     ],
 )
 def test_create_voila_manifest_2(path, entrypoint):
-    environment = Environment.from_dict(dict(
-        contents="numpy\nipywidgets\nbqplot\n",
-        error=None,
-        filename="requirements.txt",
-        locale="en_US.UTF-8",
-        package_manager="pip",
-        pip="23.0",
-        python="3.8.12",
-        source="file",
-    ))
+    environment = Environment.from_dict(
+        dict(
+            contents="numpy\nipywidgets\nbqplot\n",
+            error=None,
+            filename="requirements.txt",
+            locale="en_US.UTF-8",
+            package_manager="pip",
+            pip="23.0",
+            python="3.8.12",
+            source="file",
+        )
+    )
 
     if sys.platform == "win32":
         bqplot_hash = "b7ba4ec7b6721c86ab883f5e6e2ea68f"
@@ -1384,16 +1391,18 @@ def test_create_voila_manifest_2(path, entrypoint):
 
 
 def test_create_voila_manifest_extra():
-    environment = Environment.from_dict(dict(
-        contents="numpy\nipywidgets\nbqplot\n",
-        error=None,
-        filename="requirements.txt",
-        locale="en_US.UTF-8",
-        package_manager="pip",
-        pip="23.0.1",
-        python="3.8.12",
-        source="file",
-    ))
+    environment = Environment.from_dict(
+        dict(
+            contents="numpy\nipywidgets\nbqplot\n",
+            error=None,
+            filename="requirements.txt",
+            locale="en_US.UTF-8",
+            package_manager="pip",
+            pip="23.0.1",
+            python="3.8.12",
+            source="file",
+        )
+    )
 
     if sys.platform == "win32":
         requirements_checksum = "d51994456975ff487749acc247ae6d63"
@@ -1468,16 +1477,18 @@ def test_create_voila_manifest_extra():
     ],
 )
 def test_create_voila_manifest_multi_notebook(path, entrypoint):
-    environment = Environment.from_dict(dict(
-        contents="bqplot\n",
-        error=None,
-        filename="requirements.txt",
-        locale="en_US.UTF-8",
-        package_manager="pip",
-        pip="23.0",
-        python="3.8.12",
-        source="file",
-    ))
+    environment = Environment.from_dict(
+        dict(
+            contents="bqplot\n",
+            error=None,
+            filename="requirements.txt",
+            locale="en_US.UTF-8",
+            package_manager="pip",
+            pip="23.0",
+            python="3.8.12",
+            source="file",
+        )
+    )
 
     if sys.platform == "win32":
         bqplot_hash = "ddb4070466d3c45b2f233dd39906ddf6"
@@ -1573,16 +1584,18 @@ def test_make_voila_bundle(
     path,
     entrypoint,
 ):
-    environment = Environment.from_dict(dict(
-        contents="bqplot",
-        error=None,
-        filename="requirements.txt",
-        locale="en_US.UTF-8",
-        package_manager="pip",
-        pip="23.0",
-        python="3.8.12",
-        source="file",
-    ))
+    environment = Environment.from_dict(
+        dict(
+            contents="bqplot",
+            error=None,
+            filename="requirements.txt",
+            locale="en_US.UTF-8",
+            package_manager="pip",
+            pip="23.0",
+            python="3.8.12",
+            source="file",
+        )
+    )
 
     if sys.platform == "win32":
         checksum_hash = "b7ba4ec7b6721c86ab883f5e6e2ea68f"
@@ -1680,16 +1693,18 @@ def test_make_voila_bundle_multi_notebook(
     path,
     entrypoint,
 ):
-    environment = Environment.from_dict(dict(
-        contents="bqplot",
-        error=None,
-        filename="requirements.txt",
-        locale="en_US.UTF-8",
-        package_manager="pip",
-        pip="23.0",
-        python="3.8.12",
-        source="file",
-    ))
+    environment = Environment.from_dict(
+        dict(
+            contents="bqplot",
+            error=None,
+            filename="requirements.txt",
+            locale="en_US.UTF-8",
+            package_manager="pip",
+            pip="23.0",
+            python="3.8.12",
+            source="file",
+        )
+    )
 
     if sys.platform == "win32":
         bqplot_hash = "ddb4070466d3c45b2f233dd39906ddf6"
@@ -1769,16 +1784,18 @@ def test_make_voila_bundle_2(
     path,
     entrypoint,
 ):
-    environment = Environment.from_dict(dict(
-        contents="numpy\nipywidgets\nbqplot\n",
-        error=None,
-        filename="requirements.txt",
-        locale="en_US.UTF-8",
-        package_manager="pip",
-        pip="23.0",
-        python="3.8.12",
-        source="file",
-    ))
+    environment = Environment.from_dict(
+        dict(
+            contents="numpy\nipywidgets\nbqplot\n",
+            error=None,
+            filename="requirements.txt",
+            locale="en_US.UTF-8",
+            package_manager="pip",
+            pip="23.0",
+            python="3.8.12",
+            source="file",
+        )
+    )
 
     if sys.platform == "win32":
         bqplot_hash = "b7ba4ec7b6721c86ab883f5e6e2ea68f"
@@ -1833,16 +1850,18 @@ def test_make_voila_bundle_extra():
 
     requirements_hash = "d51994456975ff487749acc247ae6d63"
 
-    environment = Environment.from_dict(dict(
-        contents="numpy\nipywidgets\nbqplot\n",
-        error=None,
-        filename="requirements.txt",
-        locale="en_US.UTF-8",
-        package_manager="pip",
-        pip="23.0.1",
-        python="3.8.12",
-        source="file",
-    ))
+    environment = Environment.from_dict(
+        dict(
+            contents="numpy\nipywidgets\nbqplot\n",
+            error=None,
+            filename="requirements.txt",
+            locale="en_US.UTF-8",
+            package_manager="pip",
+            pip="23.0.1",
+            python="3.8.12",
+            source="file",
+        )
+    )
     ans = {
         "version": 1,
         "locale": "en_US.UTF-8",

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -15,6 +15,7 @@ from .utils import get_dir
 import pytest
 
 version_re = re.compile(r"\d+\.\d+(\.\d+)?")
+TESTDATA = os.path.join(os.path.dirname(__file__), "testdata")
 
 
 class TestEnvironment(TestCase):
@@ -130,6 +131,28 @@ class WhichPythonTestCase(TestCase):
         with tempfile.NamedTemporaryFile() as tmpfile:
             with self.assertRaises(RSConnectException):
                 which_python(tmpfile.name)
+
+
+class TestPythonVersionRequirements:
+    def test_pyproject_toml(self):
+        env = Environment.create_python_environment(os.path.join(TESTDATA, "python-project", "using_pyproject"))
+        assert env.python_interpreter == sys.executable
+        assert env.python_version_requirement == ">=3.8"
+
+    def test_python_version(self):
+        env = Environment.create_python_environment(os.path.join(TESTDATA, "python-project", "using_pyversion"))
+        assert env.python_interpreter == sys.executable
+        assert env.python_version_requirement == ">=3.8, <3.12"
+
+    def test_all_of_them(self):
+        env = Environment.create_python_environment(os.path.join(TESTDATA, "python-project", "allofthem"))
+        assert env.python_interpreter == sys.executable
+        assert env.python_version_requirement == ">=3.8, <3.12"
+
+    def test_missing(self):
+        env = Environment.create_python_environment(os.path.join(TESTDATA, "python-project", "empty"))
+        assert env.python_interpreter == sys.executable
+        assert env.python_version_requirement is None
 
 
 def test_inspect_environment():

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -42,15 +42,18 @@ class TestEnvironment(TestCase):
         self.assertIsInstance(result.locale, str)
         self.assertIn(".", result.locale)
 
-        expected = Environment.from_dict(dict(
-            contents="numpy\npandas\nmatplotlib\n",
-            filename="requirements.txt",
-            locale=result.locale,
-            package_manager="pip",
-            pip=result.pip,
-            python=self.python_version(),
-            source="file",
-        ), python_interpreter=sys.executable)
+        expected = Environment.from_dict(
+            dict(
+                contents="numpy\npandas\nmatplotlib\n",
+                filename="requirements.txt",
+                locale=result.locale,
+                package_manager="pip",
+                pip=result.pip,
+                python=self.python_version(),
+                source="file",
+            ),
+            python_interpreter=sys.executable,
+        )
         self.assertEqual(expected, result)
 
     def test_pip_freeze(self):
@@ -65,15 +68,18 @@ class TestEnvironment(TestCase):
         self.assertIsInstance(result.locale, str)
         self.assertIn(".", result.locale)
 
-        expected = Environment.from_dict(dict(
-            contents=result.contents,
-            filename="requirements.txt",
-            locale=result.locale,
-            package_manager="pip",
-            pip=result.pip,
-            python=self.python_version(),
-            source="pip_freeze",
-        ), python_interpreter=sys.executable)
+        expected = Environment.from_dict(
+            dict(
+                contents=result.contents,
+                filename="requirements.txt",
+                locale=result.locale,
+                package_manager="pip",
+                pip=result.pip,
+                python=self.python_version(),
+                source="pip_freeze",
+            ),
+            python_interpreter=sys.executable,
+        )
         self.assertEqual(expected, result)
 
     def test_filter_pip_freeze_output(self):
@@ -154,16 +160,19 @@ def test_inspect_environment_catches_type_error():
             sys.executable,
             False,
             sys.executable,
-            Environment.from_dict(dict(
-                contents=None,
-                filename="requirements.txt",
-                locale="en_US.UTF-8",
-                package_manager="pip",
-                pip=None,
-                python=None,
-                source="pip_freeze",
-                error=None,
-            ), python_interpreter=sys.executable),
+            Environment.from_dict(
+                dict(
+                    contents=None,
+                    filename="requirements.txt",
+                    locale="en_US.UTF-8",
+                    package_manager="pip",
+                    pip=None,
+                    python=None,
+                    source="pip_freeze",
+                    error=None,
+                ),
+                python_interpreter=sys.executable,
+            ),
             id="basic",
         ),
         pytest.param(
@@ -171,16 +180,19 @@ def test_inspect_environment_catches_type_error():
             os.path.basename(sys.executable),
             False,
             sys.executable,
-            Environment.from_dict(dict(
-                contents=None,
-                filename="requirements.txt",
-                locale="en_US.UTF-8",
-                package_manager="pip",
-                pip=None,
-                python=None,
-                source="pip_freeze",
-                error=None,
-            ), python_interpreter=sys.executable),
+            Environment.from_dict(
+                dict(
+                    contents=None,
+                    filename="requirements.txt",
+                    locale="en_US.UTF-8",
+                    package_manager="pip",
+                    pip=None,
+                    python=None,
+                    source="pip_freeze",
+                    error=None,
+                ),
+                python_interpreter=sys.executable,
+            ),
             id="which_python",
         ),
         pytest.param(
@@ -188,7 +200,18 @@ def test_inspect_environment_catches_type_error():
             "argh.py",
             False,
             "unused",
-            Environment.from_dict(dict(contents=None, filename=None, locale=None, package_manager=None, pip=None, python=None, source=None, error="Could not even do things")),
+            Environment.from_dict(
+                dict(
+                    contents=None,
+                    filename=None,
+                    locale=None,
+                    package_manager=None,
+                    pip=None,
+                    python=None,
+                    source=None,
+                    error="Could not even do things",
+                )
+            ),
             id="exploding",
         ),
     ],

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 import rsconnect.environment
 from rsconnect.exception import RSConnectException
 from rsconnect.environment import Environment, which_python
-from rsconnect.subprocesses.environment import get_python_version, get_default_locale, filter_pip_freeze_output
+from rsconnect.subprocesses.inspect_environment import get_python_version, get_default_locale, filter_pip_freeze_output
 
 from .utils import get_dir
 

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -7,6 +7,7 @@ from rsconnect.pyproject import (
     parse_setupcfg_python_requires,
     parse_pyversion_python_requires,
     get_python_version_requirement_parser,
+    detect_python_version_requirement,
 )
 
 import pytest
@@ -104,7 +105,7 @@ def test_pyprojecttoml_python_requires(project_dir, expected):
     ],
     ids=["option-exists", "option-missing"],
 )
-def test_setupcfg_python_requires(tmp_path, project_dir, expected):
+def test_setupcfg_python_requires(project_dir, expected):
     """Test that the python_requires field is correctly parsed from setup.cfg.
 
     Both when the option exists or when it missing in the file.
@@ -120,7 +121,7 @@ def test_setupcfg_python_requires(tmp_path, project_dir, expected):
     ],
     ids=["option-exists"],
 )
-def test_pyversion_python_requires(tmp_path, project_dir, expected):
+def test_pyversion_python_requires(project_dir, expected):
     """Test that the python version is correctly parsed from .python-version.
 
     We do not test the case where the option is missing, as an empty .python-version file
@@ -128,3 +129,16 @@ def test_pyversion_python_requires(tmp_path, project_dir, expected):
     """
     versionfile = pathlib.Path(project_dir) / ".python-version"
     assert parse_pyversion_python_requires(versionfile) == expected
+
+
+def test_detect_python_version_requirement():
+    """Test that the python version requirement is correctly detected from the metadata files.
+
+    Given that we already know from the other tests that the metadata files are correctly parsed,
+    this test primarily checks that when there are multiple metadata files, the one with the most specific
+    version requirement is used.
+    """
+    project_dir = os.path.join(PROJECTS_DIRECTORY, "allofthem")
+    assert detect_python_version_requirement(project_dir) == ">=3.8, <3.12"
+
+    assert detect_python_version_requirement(os.path.join(PROJECTS_DIRECTORY, "empty")) is None

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -50,15 +50,20 @@ def test_python_project_metadata_detect(project_dir, expected):
         ("pyproject.toml", parse_pyproject_python_requires),
         ("setup.cfg", parse_setupcfg_python_requires),
         (".python-version", parse_pyversion_python_requires),
-        ("invalid.txt", None),
+        ("invalid.txt", NotImplementedError("Unknown metadata file type: invalid.txt")),
     ],
     ids=["pyproject.toml", "setup.cfg", ".python-version", "invalid"],
 )
 def test_get_python_version_requirement_parser(filename, expected_parser):
     """Test that given a metadata file name, the correct parser is returned."""
     metadata_file = pathlib.Path(PROJECTS_DIRECTORY) / filename
-    parser = get_python_version_requirement_parser(metadata_file)
-    assert parser == expected_parser
+    if isinstance(expected_parser, Exception):
+        with pytest.raises(expected_parser.__class__) as excinfo:
+            parser = get_python_version_requirement_parser(metadata_file)
+            assert str(excinfo.value) == expected_parser.args[0]
+    else:
+        parser = get_python_version_requirement_parser(metadata_file)
+        assert parser == expected_parser
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION

## Intent

Connect supports python interpreter version requirements from the `environment.python.requires` field in the manifest.
That field should be filled based on the version requirements in the project metadata files:

- pyproject.toml
- setup.cfg
- .python-version

## Type of Change

- [x] New Feature       <!-- A change which adds additional functionality -->
- [x] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

1. Refactor the various deploy commands to generate the `Environment` information via the same code path
2. Implement support for detecting the interpreter requirement in that shared entry point
3. Write the detected constraint to the generated manifest before submitting it to the server.

## Automated Tests

- Existing test suite checks that the support for current deploys is still working as expected
- New tests check that the manifest.json gets generated with the right `environment.python.requires` field when detected

## Directions for Reviewers

- `--override-python-version` still allows overwriting the detected version, but on long term the plan is to deprecate the option and ask users to create a `.python-version` file to do the same. So that is a more standard approach in the Python ecosystem.

## Checklist

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [x] I have updated all related GitHub issues to reflect their current state.
