### PR TITLE
initial support for interacting with Connect in SPCS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ test = [
     "twine",
     "types-Flask",
 ]
+snowflake = ["snowflake-cli"]
 
 [project.urls]
 Repository = "http://github.com/posit-dev/rsconnect-python"

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -175,6 +175,14 @@ def test_rstudio_server(server: api.PositServer):
             raise RSConnectException("Failed to verify with {} ({}).".format(server.remote_name, exc))
 
 
+def test_spcs_server(server: api.SPCSServer):
+    with api.RSConnectClient(server) as client:
+        try:
+            client.me()
+        except RSConnectException as exc:
+            raise RSConnectException("Failed to verify with {} ({}).".format(server.remote_name, exc))
+
+
 def test_api_key(connect_server: api.RSConnectServer) -> str:
     """
     Test that an API Key may be used to authenticate with the given Posit Connect server.

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -234,9 +234,33 @@ class RSConnectServer(AbstractRemoteServer):
         self.ca_data = ca_data
         # This is specifically not None.
         self.cookie_jar = CookieJar()
+        # 🤡
+        self.snowflake_connection_name = None
 
 
-TargetableServer = typing.Union[ShinyappsServer, RSConnectServer, CloudServer]
+class SPCSServer(AbstractRemoteServer):
+    """
+    A class encapsulating the information required to interact with Connect in SPCS.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        snowflake_connection_name: Optional[str],
+        insecure: bool = False,
+        ca_data: Optional[str | bytes] = None,
+    ):
+        super().__init__(url, "Posit Connect")
+        self.insecure = insecure
+        self.ca_data = ca_data
+        self.snowflake_connection_name = snowflake_connection_name
+        # for compatibility with RSConnectClient
+        self.cookie_jar = CookieJar()
+        self.api_key = None
+        self.bootstrap_jwt = None
+
+
+TargetableServer = typing.Union[ShinyappsServer, RSConnectServer, CloudServer, SPCSServer]
 
 
 class S3Server(AbstractRemoteServer):
@@ -253,7 +277,7 @@ class RSConnectClientDeployResult(TypedDict):
 
 
 class RSConnectClient(HTTPServer):
-    def __init__(self, server: RSConnectServer, cookies: Optional[CookieJar] = None):
+    def __init__(self, server: RSConnectServer | SPCSServer, cookies: Optional[CookieJar] = None):
         if cookies is None:
             cookies = server.cookie_jar
         super().__init__(
@@ -269,6 +293,14 @@ class RSConnectClient(HTTPServer):
 
         if server.bootstrap_jwt:
             self.bootstrap_authorization(server.bootstrap_jwt)
+
+        if server.snowflake_connection_name:
+            from .snowflake import SnowflakeExchangeClient, get_token_endpoint
+
+            token_endpoint = get_token_endpoint(server.snowflake_connection_name)
+            snowflake_client = SnowflakeExchangeClient(token_endpoint)
+            token = snowflake_client.exchange_token(server.url, server.snowflake_connection_name)
+            self.snowflake_authorization(token)
 
     def _tweak_response(self, response: HTTPResponse) -> JsonData | HTTPResponse:
         return (
@@ -554,6 +586,7 @@ class RSConnectExecutor:
         name: Optional[str] = None,
         url: Optional[str] = None,
         api_key: Optional[str] = None,
+        snowflake_connection_name: Optional[str] = None,
         insecure: bool = False,
         cacert: Optional[str] = None,
         ca_data: Optional[str | bytes] = None,
@@ -603,6 +636,7 @@ class RSConnectExecutor:
             name=name,
             url=url or server,
             api_key=api_key,
+            snowflake_connection_name=snowflake_connection_name,
             insecure=insecure,
             cacert=cacert,
             ca_data=ca_data,
@@ -688,6 +722,7 @@ class RSConnectExecutor:
         name: Optional[str] = None,
         url: Optional[str] = None,
         api_key: Optional[str] = None,
+        snowflake_connection_name: Optional[str] = None,
         insecure: bool = False,
         cacert: Optional[str] = None,
         ca_data: Optional[str | bytes] = None,
@@ -699,6 +734,7 @@ class RSConnectExecutor:
             ctx=ctx,
             url=url,
             api_key=api_key,
+            snowflake_connection_name=snowflake_connection_name,
             insecure=insecure,
             cacert=cacert,
             account_name=account_name,
@@ -740,12 +776,16 @@ class RSConnectExecutor:
             account_name = server_data.account_name or account_name
             token = server_data.token or token
             secret = server_data.secret or secret
+            snowflake_connection_name = server_data.snowflake_connection_name or snowflake_connection_name
 
         self.is_server_from_store = server_data.from_store
 
         if api_key:
             url = cast(str, url)
             self.remote_server = RSConnectServer(url, api_key, insecure, ca_data)
+        elif snowflake_connection_name:
+            url = cast(str, url)
+            self.remote_server = SPCSServer(url, snowflake_connection_name)
         elif token and secret:
             if url and ("rstudio.cloud" in url or "posit.cloud" in url):
                 account_name = cast(str, account_name)
@@ -760,6 +800,8 @@ class RSConnectExecutor:
     def setup_client(self, cookies: Optional[CookieJar] = None):
         if isinstance(self.remote_server, RSConnectServer):
             self.client = RSConnectClient(self.remote_server, cookies)
+        elif isinstance(self.remote_server, SPCSServer):
+            self.client = RSConnectClient(self.remote_server)
         elif isinstance(self.remote_server, PositServer):
             self.client = PositClient(self.remote_server)
         else:
@@ -773,7 +815,9 @@ class RSConnectExecutor:
         """
         Validate that there is enough information to talk to shinyapps.io or a Connect server.
         """
-        if isinstance(self.remote_server, RSConnectServer):
+        if isinstance(self.remote_server, SPCSServer):
+            self.validate_spcs_server()
+        elif isinstance(self.remote_server, RSConnectServer):
             self.validate_connect_server()
         elif isinstance(self.remote_server, PositServer):
             self.validate_posit_server()
@@ -811,6 +855,23 @@ class RSConnectExecutor:
 
         self.remote_server = connect_server
         self.client = RSConnectClient(self.remote_server)
+
+        return self
+
+    def validate_spcs_server(self):
+        if not isinstance(self.remote_server, SPCSServer):
+            raise RSConnectException("remote_server must be a Connect server in SPCS")
+
+        url = self.remote_server.url
+        snowflake_connection_name = self.remote_server.snowflake_connection_name
+        server = SPCSServer(url, snowflake_connection_name)
+
+        with RSConnectClient(server) as client:
+            try:
+                result = client.me()
+                result = server.handle_bad_response(result)
+            except RSConnectException as exc:
+                raise RSConnectException(f"Failed to verify with {server.remote_name} ({exc})")
 
         return self
 
@@ -884,7 +945,7 @@ class RSConnectExecutor:
         if self.bundle is None:
             raise RSConnectException("A bundle must be created before deploying it.")
 
-        if isinstance(self.remote_server, RSConnectServer):
+        if isinstance(self.remote_server, RSConnectServer | SPCSServer):
             if not isinstance(self.client, RSConnectClient):
                 raise RSConnectException("client must be an RSConnectClient.")
             result = self.client.deploy(

--- a/rsconnect/http_support.py
+++ b/rsconnect/http_support.py
@@ -199,7 +199,11 @@ class HTTPResponse(object):
                 and self.response_body is not None
                 and len(self.response_body) > 0
             ):
-                self.json_data = json.loads(self.response_body)
+                try:
+                    self.json_data = json.loads(self.response_body)
+                # snowflake crudo
+                except json.decoder.JSONDecodeError:
+                    self.response_body
 
 
 class HTTPServer(object):
@@ -255,6 +259,9 @@ class HTTPServer(object):
 
     def bootstrap_authorization(self, key: str):
         self.authorization("Connect-Bootstrap %s" % key)
+
+    def snowflake_authorization(self, token: str):
+        self.authorization('Snowflake Token="%s"' % token)
 
     def _get_full_path(self, path: str):
         return append_to_path(self._url.path, path)

--- a/rsconnect/metadata.py
+++ b/rsconnect/metadata.py
@@ -244,6 +244,7 @@ class ServerDataDict(TypedDict):
     name: str
     url: str
     api_key: NotRequired[str]
+    snowflake_connection_name: NotRequired[str]
     insecure: NotRequired[bool]
     ca_cert: NotRequired[str]
     account_name: NotRequired[str]
@@ -263,6 +264,7 @@ class ServerData:
         url: str,
         from_store: bool,
         api_key: Optional[str] = None,
+        snowflake_connection_name: Optional[str] = None,
         insecure: Optional[bool] = None,
         ca_data: Optional[str] = None,
         account_name: Optional[str] = None,
@@ -273,6 +275,7 @@ class ServerData:
         self.url = url
         self.from_store = from_store
         self.api_key = api_key
+        self.snowflake_connection_name = snowflake_connection_name
         self.insecure = insecure
         self.ca_data = ca_data
         self.account_name = account_name
@@ -320,6 +323,7 @@ class ServerStore(DataStore[ServerDataDict]):
         name: str,
         url: str,
         api_key: Optional[str] = None,
+        snowflake_connection_name: Optional[str] = None,
         insecure: Optional[bool] = False,
         ca_data: Optional[str] = None,
         account_name: Optional[str] = None,
@@ -332,6 +336,7 @@ class ServerStore(DataStore[ServerDataDict]):
         :param name: the nickname for the Connect server.
         :param url: the full URL for the Connect server.
         :param api_key: the API key to use to authenticate with the Connect server.
+        :param snowflake_connection_name: the snowflake connection name
         :param insecure: a flag to disable TLS verification.
         :param ca_data: client side certificate data to use for TLS.
         :param account_name: shinyapps.io account name.
@@ -344,6 +349,8 @@ class ServerStore(DataStore[ServerDataDict]):
         }
         if api_key:
             target_data = dict(api_key=api_key, insecure=insecure, ca_cert=ca_data)
+        elif snowflake_connection_name:
+            target_data = dict(snowflake_connection_name=snowflake_connection_name)
         elif account_name:
             target_data = dict(account_name=account_name, token=token, secret=secret)
         else:
@@ -406,6 +413,7 @@ class ServerStore(DataStore[ServerDataDict]):
                 name,
                 entry["url"],
                 True,
+                snowflake_connection_name=entry.get("snowflake_connection_name"),
                 insecure=entry.get("insecure"),
                 ca_data=entry.get("ca_cert"),
                 api_key=entry.get("api_key"),

--- a/rsconnect/snowflake.py
+++ b/rsconnect/snowflake.py
@@ -1,0 +1,122 @@
+import json
+import subprocess
+from typing import Any, Dict, Optional
+from urllib.parse import urlencode, urlparse
+
+import requests
+
+from .exception import RSConnectException
+from .http_support import HTTPServer
+
+
+def is_snow_installed() -> bool:
+    try:
+        import snowflake.cli  # noqa
+
+        return True
+    except ImportError:
+        try:
+            subprocess.run(["snow", "--help"], capture_output=True)
+            return True
+        except OSError:
+            return False
+
+
+def list_connections():
+
+    if not is_snow_installed():
+        raise RSConnectException(
+            "The snowflake-cli is required bit not installed."
+            "Install it with 'pip install rsconnect-python[snowflake]'"
+        )
+    snow_cx_list = subprocess.run(
+        ["snow", "connection", "list", "--format", "json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    connection_list = json.loads(snow_cx_list.stdout)
+    return connection_list
+
+
+def get_connection(name: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    connection_list = list_connections()
+
+    if not name:
+        return next((x["parameters"] for x in connection_list if x.get("is_default")), None)
+    else:
+        return next((x["parameters"] for x in connection_list if x.get("connection_name") == name), None)
+
+
+def get_jwt(snowflake_connection_name: Optional[str] = None):
+    connection_name = "" if snowflake_connection_name is None else snowflake_connection_name
+    snow_cx_jwt = subprocess.run(
+        args=["snow", "connection", "generate-jwt", "--connection", connection_name, "--format", "json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    output = json.loads(snow_cx_jwt.stdout)
+    jwt = output.get("message")
+    return jwt
+
+
+def get_access_token(spcs_endpoint: str, snowflake_connection_name: Optional[str] = None) -> str:
+
+    cx = get_connection(snowflake_connection_name)
+    if cx is None:
+        raise RSConnectException("No Snowflake connection found")
+    spcs_url = urlparse(spcs_endpoint)
+
+    token_endpoint = f"https://{cx["account"]}.snowflakecomputing.com/oauth/token"
+    scope = f"session:role:{cx["role"]} {spcs_url.netloc}"
+    jwt = get_jwt(snowflake_connection_name)
+    GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+
+    payload = {"scope": scope, "assertion": jwt, "grant_type": GRANT_TYPE}
+
+    r = requests.post(url=token_endpoint, data=payload)
+    r.raise_for_status()
+
+    return r.text
+
+
+def get_token_endpoint(snowflake_connection_name: Optional[str] = None) -> str:
+    cx = get_connection(snowflake_connection_name)
+    if cx is None:
+        raise RSConnectException("No Snowflake connection found")
+
+    return f"https://{cx["account"]}.snowflakecomputing.com/"
+
+
+class SnowflakeExchangeClient(HTTPServer):
+
+    def fmt_payload(self, spcs_endpoint: str, snowflake_connection_name: Optional[str] = None):
+        cx = get_connection(snowflake_connection_name)
+        if cx is None:
+            raise RSConnectException("No Snowflake connection found")
+        spcs_url = urlparse(spcs_endpoint)
+
+        scope = f"session:role:{cx["role"]} {spcs_url.netloc}"
+        jwt = get_jwt(snowflake_connection_name)
+        grant_type = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+
+        payload = {"scope": scope, "assertion": jwt, "grant_type": grant_type}
+        payload = urlencode(payload)
+        return payload
+
+    def exchange_token(self, spcs_endpoint: str, snowflake_connection_name: Optional[str] = None):
+
+        payload = self.fmt_payload(spcs_endpoint, snowflake_connection_name)
+
+        response = self.request(
+            method="POST",
+            path="/oauth/token",
+            body=payload,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+        if response.response_body:
+            return response.response_body
+
+        return None

--- a/rsconnect/snowflake.py
+++ b/rsconnect/snowflake.py
@@ -3,8 +3,6 @@ import subprocess
 from typing import Any, Dict, Optional
 from urllib.parse import urlencode, urlparse
 
-import requests
-
 from .exception import RSConnectException
 from .http_support import HTTPServer
 
@@ -59,26 +57,6 @@ def get_jwt(snowflake_connection_name: Optional[str] = None):
     output = json.loads(snow_cx_jwt.stdout)
     jwt = output.get("message")
     return jwt
-
-
-def get_access_token(spcs_endpoint: str, snowflake_connection_name: Optional[str] = None) -> str:
-
-    cx = get_connection(snowflake_connection_name)
-    if cx is None:
-        raise RSConnectException("No Snowflake connection found")
-    spcs_url = urlparse(spcs_endpoint)
-
-    token_endpoint = f"https://{cx["account"]}.snowflakecomputing.com/oauth/token"
-    scope = f"session:role:{cx["role"]} {spcs_url.netloc}"
-    jwt = get_jwt(snowflake_connection_name)
-    GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer"
-
-    payload = {"scope": scope, "assertion": jwt, "grant_type": GRANT_TYPE}
-
-    r = requests.post(url=token_endpoint, data=payload)
-    r.raise_for_status()
-
-    return r.text
 
 
 def get_token_endpoint(snowflake_connection_name: Optional[str] = None) -> str:

--- a/rsconnect/validation.py
+++ b/rsconnect/validation.py
@@ -45,6 +45,7 @@ def validate_connection_options(
     token: Optional[str],
     secret: Optional[str],
     name: Optional[str] = None,
+    snowflake_connection_name: Optional[str] = None,
 ):
     """
     Validates provided Connect or shinyapps.io connection options and returns which target to use given the provided
@@ -63,6 +64,7 @@ def validate_connection_options(
     -T/--token or SHINYAPPS_TOKEN or RSCLOUD_TOKEN
     -S/--secret or SHINYAPPS_SECRET or RSCLOUD_SECRET
     -A/--account or SHINYAPPS_ACCOUNT
+    --snowflake-connection-name
 
     FAILURE if any of:
     -k/--api-key or CONNECT_API_KEY
@@ -72,6 +74,7 @@ def validate_connection_options(
     -T/--token or SHINYAPPS_TOKEN or RSCLOUD_TOKEN
     -S/--secret or SHINYAPPS_SECRET or RSCLOUD_SECRET
     -A/--account or SHINYAPPS_ACCOUNT
+    --snowflake-connection-name
 
     FAILURE if specify -s/--server or CONNECT_SERVER and it includes "posit.cloud" or "rstudio.cloud"
     and not specified all of following:
@@ -82,10 +85,15 @@ def validate_connection_options(
     -T/--token or SHINYAPPS_TOKEN or RSCLOUD_TOKEN
     -S/--secret or SHINYAPPS_SECRET or RSCLOUD_SECRET
     -A/--account or SHINYAPPS_ACCOUNT
+
+    FAILURE if -s/--server or CONNECT_SERVER include "snowflakecomputing.app"
+    and not
+    --snowflake-connection-name
     """
     connect_options = {"-k/--api-key": api_key, "-i/--insecure": insecure, "-c/--cacert": cacert}
     shinyapps_options = {"-T/--token": token, "-S/--secret": secret, "-A/--account": account_name}
     cloud_options = {"-T/--token": token, "-S/--secret": secret}
+    spcs_options = {"--snowflake-connection-name": snowflake_connection_name}
     options_mutually_exclusive_with_name = {"-s/--server": url, **shinyapps_options}
     present_options_mutually_exclusive_with_name = _get_present_options(options_mutually_exclusive_with_name, ctx)
 
@@ -105,11 +113,25 @@ either via command options or environment variables. See command help for furthe
     present_connect_options = _get_present_options(connect_options, ctx)
     present_shinyapps_options = _get_present_options(shinyapps_options, ctx)
     present_cloud_options = _get_present_options(cloud_options, ctx)
+    present_spcs_options = _get_present_options(spcs_options, ctx)
 
     if present_connect_options and present_shinyapps_options:
         raise RSConnectException(
             f"Connect options ({', '.join(present_connect_options)}) may not be passed \
 alongside shinyapps.io or Posit Cloud options ({', '.join(present_shinyapps_options)}). \
+See command help for further details."
+        )
+
+    if snowflake_connection_name and not url:
+        raise RSConnectException(
+            "--snowflake-connection-name requires -s/--server to be specified. \
+See command help for further details."
+        )
+
+    if present_shinyapps_options and present_spcs_options:
+        raise RSConnectException(
+            f"Shinyapps.io/Cloud options ({', '.join(present_shinyapps_options)}) may not be passed \
+alongside SPCS options ({', '.join(present_spcs_options)}). \
 See command help for further details."
         )
 


### PR DESCRIPTION
Initial SPCS support

## Intent


## Type of Change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- If you check more than one box, you may need to refactor this change into separate pull requests -->

- [ ] Bug Fix           <!-- A change which fixes an existing issue -->
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

Take an optional dependency on the `snow` CLI
commands requiring interaction with remote servers gain an optional `--snowflake-connection-name` argument
The ingress URL, account name, and keypair configured out of band are sufficient information
to obtain the OAuth token required to interact with Connect in SPCS.

supports rsconnect add, details, and deploy_html

## Automated Tests
<!-- Describe the automated tests associated with this change. -->
<!-- If automated tests are not included in this change, please state why. -->

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
