### PR TITLE
Warning about --python and --override-python-version deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `rsconnect` now detects Python interpreter version requirements from
   `.python-version`, `pyproject.toml` and `setup.cfg`
+- `--python` and `--override-python-version` options are now deprecated
+  in favor of using `.python-version` requirement file.
 
 ## [1.25.2] - 2025-02-26
 

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -129,9 +129,10 @@ class Environment:
         _warn_on_missing_python_version(python_version_requirement)
 
         if override_python_version:
-            # TODO: --override-python-version should be deprecated in the future
-            #       and instead we should suggest the user sets it in .python-version
-            #       or pyproject.toml
+            logger.warning(
+                "The --override-python-version option is deprecated, "
+                "please use a .python-version file to force a specific interpreter version."
+            )
             python_version_requirement = f"=={override_python_version}"
 
         # with cli_feedback("Inspecting Python environment"):

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -128,7 +128,16 @@ class Environment:
         python_version_requirement = pyproject.detect_python_version_requirement(directory)
         _warn_on_missing_python_version(python_version_requirement)
 
+        if python is not None:
+            # TODO: Remove the option in a future release
+            logger.warning(
+                "On modern connect versions, the --python option won't influence "
+                "the Python version used to deploy the application anymore. "
+                "Please use a .python-version file to force a specific interpreter version."
+            )
+
         if override_python_version:
+            # TODO: Remove the option in a future release
             logger.warning(
                 "The --override-python-version option is deprecated, "
                 "please use a .python-version file to force a specific interpreter version."

--- a/rsconnect/environment.py
+++ b/rsconnect/environment.py
@@ -131,7 +131,7 @@ class Environment:
         if python is not None:
             # TODO: Remove the option in a future release
             logger.warning(
-                "On modern connect versions, the --python option won't influence "
+                "On modern Posit Connect versions, the --python option won't influence "
                 "the Python version used to deploy the application anymore. "
                 "Please use a .python-version file to force a specific interpreter version."
             )

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -300,7 +300,7 @@ class TestEnvironmentDeprecations:
             result = Environment.create_python_environment(get_dir("pip1"), python=sys.executable)
         assert mock_warning.call_count == 1
         mock_warning.assert_called_once_with(
-            "On modern connect versions, the --python option won't influence "
+            "On modern Posit Connect versions, the --python option won't influence "
             "the Python version used to deploy the application anymore. "
             "Please use a .python-version file to force a specific interpreter version."
         )

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -287,3 +287,21 @@ class TestEnvironmentDeprecations:
             "please use a .python-version file to force a specific interpreter version."
         )
         assert result.python_version_requirement == "==3.8"
+
+    def test_python_interpreter(self):
+        current_python_version = ".".join((str(v) for v in sys.version_info[:3]))
+
+        with mock.patch.object(rsconnect.environment.logger, "warning") as mock_warning:
+            result = Environment.create_python_environment(get_dir("pip1"))
+        assert mock_warning.call_count == 0
+        assert result.python == current_python_version
+
+        with mock.patch.object(rsconnect.environment.logger, "warning") as mock_warning:
+            result = Environment.create_python_environment(get_dir("pip1"), python=sys.executable)
+        assert mock_warning.call_count == 1
+        mock_warning.assert_called_once_with(
+            "On modern connect versions, the --python option won't influence "
+            "the Python version used to deploy the application anymore. "
+            "Please use a .python-version file to force a specific interpreter version."
+        )
+        assert result.python == current_python_version

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import subprocess
 from unittest import TestCase
+from unittest import mock
 
 import rsconnect.environment
 from rsconnect.exception import RSConnectException
@@ -270,3 +271,19 @@ def test_get_python_env_info(
 
         assert environment.python_interpreter == expected_python
         assert environment == expected_environment
+
+class TestEnvironmentDeprecations:
+    def test_override_python_version(self):
+        with mock.patch.object(rsconnect.environment.logger, "warning") as mock_warning:
+            result = Environment.create_python_environment(get_dir("pip1"), override_python_version=None)
+        assert mock_warning.call_count == 0
+        assert result.python_version_requirement is None
+
+        with mock.patch.object(rsconnect.environment.logger, "warning") as mock_warning:
+            result = Environment.create_python_environment(get_dir("pip1"), override_python_version="3.8")
+        assert mock_warning.call_count == 1
+        mock_warning.assert_called_once_with(
+            "The --override-python-version option is deprecated, "
+            "please use a .python-version file to force a specific interpreter version."
+        )
+        assert result.python_version_requirement == "==3.8"


### PR DESCRIPTION
## Intent

The intent is moving the user toward best practices of using a `.python-version` file when a specific version of Python has to be used to deploy the project. That relies on a standard way to specific version requirements and allows the requirement to be packaged/committed with the project thus making deploys reproducible.

* The `--override-python-version` option isn't needed anymore when `.python-version` is supported and using it made the deploy unreproducible
* The `--python` option is confusing in itself, as it refers to the python interpreter used to run `rsconnect` and on latest connect versions (>=2025.03) it doesn't influence the interpreter used to run the content anymore. The fact that it previously did was practically a side effect. Deprecating it gives the user a suggestion for a reliable and predictable way to specify the python interpreter.

As the `--python` option does no longer influence the interpreter in use itself, but it's only used to detect the environment requirements, I made #656 to change the name to something that better conveys its purpose in the future.

## Type of Change

- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

Add a deprecation message without disabling the existing option.
This will start suggesting users to embrace the best practice and give them time to migrate.
In the future we will be able to drop the options as users migrated away from them.

## Automated Tests

Two tests were added asserting the the deprecation messages are correctly emitted

## Directions for Reviewers
<!-- Provide steps for reviewers to validate this change manually. -->

## Checklist

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
