### PR TITLE
spcs support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
@@ -254,5 +255,3 @@ jobs:
               name: cypress-screenshots_${{ matrix.PY_VERSION }}_native
               path: test/connect-rsconnect-python/cypress/screenshots
               if-no-files-found: ignore
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for interaction with Posit Connect deployments
+  hosted in Snowpark Container Services.
 - `rsconnect` now detects Python interpreter version requirements from
   `.python-version`, `pyproject.toml` and `setup.cfg`
 - `--python` and `--override-python-version` options are now deprecated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ test = [
     "twine",
     "types-Flask",
 ]
+snowflake = ["snowflake-cli"]
 
 [project.urls]
 Repository = "http://github.com/posit-dev/rsconnect-python"

--- a/rsconnect/actions.py
+++ b/rsconnect/actions.py
@@ -172,6 +172,14 @@ def test_rstudio_server(server: api.PositServer):
             raise RSConnectException("Failed to verify with {} ({}).".format(server.remote_name, exc))
 
 
+def test_spcs_server(server: api.SPCSConnectServer):
+    with api.RSConnectClient(server) as client:
+        try:
+            client.me()
+        except RSConnectException as exc:
+            raise RSConnectException("Failed to verify with {} ({}).".format(server.remote_name, exc))
+
+
 def test_api_key(connect_server: api.RSConnectServer) -> str:
     """
     Test that an API Key may be used to authenticate with the given Posit Connect server.

--- a/rsconnect/actions_content.py
+++ b/rsconnect/actions_content.py
@@ -9,11 +9,11 @@ import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta
-from typing import Iterator, Literal, Optional, Sequence, cast
+from typing import Iterator, Literal, Optional, Sequence, cast, Union
 
 import semver
 
-from .api import RSConnectClient, RSConnectServer, emit_task_log
+from .api import RSConnectServer, SPCSConnectServer, RSConnectClient, emit_task_log
 from .exception import RSConnectException
 from .log import logger
 from .metadata import ContentBuildStore, ContentItemWithBuildState
@@ -33,7 +33,7 @@ def content_build_store() -> ContentBuildStore:
     return _content_build_store
 
 
-def ensure_content_build_store(connect_server: RSConnectServer) -> ContentBuildStore:
+def ensure_content_build_store(connect_server: Union[RSConnectServer, SPCSConnectServer]) -> ContentBuildStore:
     global _content_build_store
     if not _content_build_store:
         logger.info("Initializing ContentBuildStore for %s" % connect_server.url)
@@ -42,7 +42,7 @@ def ensure_content_build_store(connect_server: RSConnectServer) -> ContentBuildS
 
 
 def build_add_content(
-    connect_server: RSConnectServer,
+    connect_server: Union[RSConnectServer, SPCSConnectServer],
     content_guids_with_bundle: Sequence[ContentGuidWithBundle],
 ):
     """
@@ -85,7 +85,7 @@ def _validate_build_rm_args(guid: Optional[str], all: bool, purge: bool):
 
 
 def build_remove_content(
-    connect_server: RSConnectServer,
+    connect_server: Union[RSConnectServer, SPCSConnectServer],
     guid: Optional[str],
     all: bool,
     purge: bool,
@@ -109,7 +109,7 @@ def build_remove_content(
     return guids
 
 
-def build_list_content(connect_server: RSConnectServer, guid: str, status: Optional[str]):
+def build_list_content(connect_server: Union[RSConnectServer, SPCSConnectServer], guid: str, status: Optional[str]):
     build_store = ensure_content_build_store(connect_server)
     if guid:
         return [build_store.get_content_item(g) for g in guid]
@@ -117,12 +117,12 @@ def build_list_content(connect_server: RSConnectServer, guid: str, status: Optio
         return build_store.get_content_items(status=status)
 
 
-def build_history(connect_server: RSConnectServer, guid: str):
+def build_history(connect_server: Union[RSConnectServer, SPCSConnectServer], guid: str):
     return ensure_content_build_store(connect_server).get_build_history(guid)
 
 
 def build_start(
-    connect_server: RSConnectServer,
+    connect_server: Union[RSConnectServer, SPCSConnectServer],
     parallelism: int,
     aborted: bool = False,
     error: bool = False,
@@ -251,7 +251,9 @@ def build_start(
             build_monitor.shutdown()
 
 
-def _monitor_build(connect_server: RSConnectServer, content_items: list[ContentItemWithBuildState]):
+def _monitor_build(
+    connect_server: Union[RSConnectServer, SPCSConnectServer], content_items: list[ContentItemWithBuildState]
+):
     """
     :return bool: True if the build completed without errors, False otherwise
     """
@@ -296,7 +298,9 @@ def _monitor_build(connect_server: RSConnectServer, content_items: list[ContentI
     return True
 
 
-def _build_content_item(connect_server: RSConnectServer, content: ContentItemWithBuildState, poll_wait: int):
+def _build_content_item(
+    connect_server: Union[RSConnectServer, SPCSConnectServer], content: ContentItemWithBuildState, poll_wait: int
+):
     build_store = ensure_content_build_store(connect_server)
     with RSConnectClient(connect_server) as client:
         # Pending futures will still try to execute when ThreadPoolExecutor.shutdown() is called
@@ -351,7 +355,7 @@ def _build_content_item(connect_server: RSConnectServer, content: ContentItemWit
 
 
 def emit_build_log(
-    connect_server: RSConnectServer,
+    connect_server: Union[RSConnectServer, SPCSConnectServer],
     guid: str,
     format: str,
     task_id: Optional[str] = None,
@@ -369,7 +373,7 @@ def emit_build_log(
         raise RSConnectException("Log file not found for content: %s" % guid)
 
 
-def download_bundle(connect_server: RSConnectServer, guid_with_bundle: ContentGuidWithBundle):
+def download_bundle(connect_server: Union[RSConnectServer, SPCSConnectServer], guid_with_bundle: ContentGuidWithBundle):
     """
     :param guid_with_bundle: models.ContentGuidWithBundle
     """
@@ -387,7 +391,7 @@ def download_bundle(connect_server: RSConnectServer, guid_with_bundle: ContentGu
         return client.download_bundle(guid_with_bundle.guid, guid_with_bundle.bundle_id)
 
 
-def get_content(connect_server: RSConnectServer, guid: str | list[str]):
+def get_content(connect_server: Union[RSConnectServer, SPCSConnectServer], guid: str | list[str]):
     """
     :param guid: a single guid as a string or list of guids.
     :return: a list of content items.
@@ -401,7 +405,7 @@ def get_content(connect_server: RSConnectServer, guid: str | list[str]):
 
 
 def search_content(
-    connect_server: RSConnectServer,
+    connect_server: Union[RSConnectServer, SPCSConnectServer],
     published: bool,
     unpublished: bool,
     content_type: Sequence[str],

--- a/rsconnect/http_support.py
+++ b/rsconnect/http_support.py
@@ -199,7 +199,12 @@ class HTTPResponse(object):
                 and self.response_body is not None
                 and len(self.response_body) > 0
             ):
-                self.json_data = json.loads(self.response_body)
+                try:
+                    self.json_data = json.loads(self.response_body)
+                # if non-empty response body is described by response headers as JSON but JSON decoding fails
+                # return the response body
+                except json.decoder.JSONDecodeError:
+                    self.response_body
 
 
 class HTTPServer(object):
@@ -255,6 +260,9 @@ class HTTPServer(object):
 
     def bootstrap_authorization(self, key: str):
         self.authorization("Connect-Bootstrap %s" % key)
+
+    def snowflake_authorization(self, token: str):
+        self.authorization('Snowflake Token="%s"' % token)
 
     def _get_full_path(self, path: str):
         return append_to_path(self._url.path, path)

--- a/rsconnect/snowflake.py
+++ b/rsconnect/snowflake.py
@@ -1,0 +1,77 @@
+# pyright: reportMissingTypeStubs=false, reportUnusedImport=false
+from __future__ import annotations
+
+import json
+from subprocess import CalledProcessError, CompletedProcess, run
+from typing import Any, Dict, List, Optional
+
+from .exception import RSConnectException
+from .log import logger
+
+
+def snow(*args: str) -> CompletedProcess[str]:
+    ensure_snow_installed()
+    return run(["snow"] + list(args), capture_output=True, text=True, check=True)
+
+
+def ensure_snow_installed() -> None:
+    try:
+        import snowflake.cli  # noqa: F401
+
+        logger.debug("snowflake-cli is installed.")
+
+    except ImportError:
+        logger.warning("snowflake-cli is not installed.")
+        try:
+            run(["snow", "--version"], capture_output=True, check=True)
+        except CalledProcessError:
+            raise RSConnectException("snow is installed but could not be run.")
+        except FileNotFoundError:
+            raise RSConnectException("snow cannot be found.")
+
+
+def list_connections() -> List[Dict[str, Any]]:
+
+    try:
+        res = snow("connection", "list", "--format", "json")
+        connection_list = json.loads(res.stdout)
+        return connection_list
+    except CalledProcessError:
+        raise RSConnectException("Could not list snowflake connections.")
+
+
+def get_connection_parameters(name: Optional[str] = None) -> Optional[Dict[str, Any]]:
+
+    connection_list = list_connections()
+    # return parameters for default connection if configured
+    # otherwise return named connection
+
+    if not connection_list:
+        raise RSConnectException("No Snowflake connections found.")
+
+    try:
+        if not name:
+            return next((x["parameters"] for x in connection_list if x.get("is_default")), None)
+        else:
+            return next((x["parameters"] for x in connection_list if x.get("connection_name") == name))
+    except StopIteration:
+        raise RSConnectException(f"No Snowflake connection found with name '{name}'.")
+
+
+def generate_jwt(name: Optional[str] = None) -> str:
+
+    _ = get_connection_parameters(name)
+    connection_name = "" if name is None else name
+
+    try:
+        res = snow("connection", "generate-jwt", "--connection", connection_name, "--format", "json")
+        try:
+            output = json.loads(res.stdout)
+        except json.JSONDecodeError:
+            raise RSConnectException(f"Failed to parse JSON from snow-cli: {res.stdout}")
+        jwt = output.get("message")
+        if jwt is None:
+            raise RSConnectException(f"Failed to generate JWT: Missing 'message' field in response: {output}")
+        return jwt
+    except CalledProcessError as e:
+        raise RSConnectException(f"Failed to generate JWT for connection '{name}': {e.stderr}")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,7 @@ from rsconnect.api import (
     RSConnectServer,
     ShinyappsServer,
     ShinyappsService,
+    SPCSConnectServer,
 )
 from rsconnect.exception import DeploymentFailedException, RSConnectException
 from rsconnect.models import AppModes
@@ -508,3 +509,132 @@ class CloudServiceTestCase(TestCase):
         self.cloud_client.deploy_application.assert_called_with(bundle_id, app_id)
         self.cloud_client.wait_until_task_is_successful.assert_called_with(task_id)
         self.cloud_client.get_task_logs.assert_called_with(task_id)
+
+
+class SPCSConnectServerTestCase(TestCase):
+    def test_init(self):
+        server = SPCSConnectServer("https://spcs.example.com", "example_connection")
+        assert server.url == "https://spcs.example.com"
+        assert server.remote_name == "Posit Connect (SPCS)"
+        assert server.snowflake_connection_name == "example_connection"
+        assert server.api_key is None
+
+    @patch("rsconnect.api.SPCSConnectServer.token_endpoint")
+    def test_token_endpoint(self, mock_token_endpoint):
+        server = SPCSConnectServer("https://spcs.example.com", "example_connection")
+        mock_token_endpoint.return_value = "https://example.snowflakecomputing.com/"
+        endpoint = server.token_endpoint()
+        assert endpoint == "https://example.snowflakecomputing.com/"
+
+    @patch("rsconnect.api.get_connection_parameters")
+    def test_token_endpoint_with_account(self, mock_get_connection_parameters):
+        server = SPCSConnectServer("https://spcs.example.com", "example_connection")
+        mock_get_connection_parameters.return_value = {"account": "test_account"}
+        endpoint = server.token_endpoint()
+        assert endpoint == "https://test_account.snowflakecomputing.com/"
+        mock_get_connection_parameters.assert_called_once_with("example_connection")
+
+    @patch("rsconnect.api.get_connection_parameters")
+    def test_token_endpoint_with_none_params(self, mock_get_connection_parameters):
+        server = SPCSConnectServer("https://spcs.example.com", "example_connection")
+        mock_get_connection_parameters.return_value = None
+        with pytest.raises(RSConnectException, match="No Snowflake connection found."):
+            server.token_endpoint()
+
+    @patch("rsconnect.api.get_connection_parameters")
+    def test_fmt_payload(self, mock_get_connection_parameters):
+        server = SPCSConnectServer("https://spcs.example.com", "example_connection")
+        mock_get_connection_parameters.return_value = {"account": "test_account", "role": "test_role"}
+
+        with patch("rsconnect.api.generate_jwt") as mock_generate_jwt:
+            mock_generate_jwt.return_value = "mocked_jwt"
+            payload = server.fmt_payload()
+
+            assert "scope=session%3Arole%3Atest_role+spcs.example.com" in payload
+            assert "assertion=mocked_jwt" in payload
+            assert "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer" in payload
+
+            mock_get_connection_parameters.assert_called_once_with("example_connection")
+            mock_generate_jwt.assert_called_once_with("example_connection")
+
+    @patch("rsconnect.api.get_connection_parameters")
+    def test_fmt_payload_with_none_params(self, mock_get_connection_parameters):
+        server = SPCSConnectServer("https://spcs.example.com", "example_connection")
+        mock_get_connection_parameters.return_value = None
+        with pytest.raises(RSConnectException, match="No Snowflake connection found."):
+            server.fmt_payload()
+
+    @patch("rsconnect.api.HTTPServer")
+    @patch("rsconnect.api.SPCSConnectServer.token_endpoint")
+    @patch("rsconnect.api.SPCSConnectServer.fmt_payload")
+    def test_exchange_token_success(self, mock_fmt_payload, mock_token_endpoint, mock_http_server):
+        server = SPCSConnectServer("https://spcs.example.com", "example_connection")
+
+        # Mock the HTTP request
+        mock_server_instance = mock_http_server.return_value
+        mock_response = Mock()
+        mock_response.status = 200
+        mock_response.response_body = "token_data"
+        mock_server_instance.request.return_value = mock_response
+
+        # Mock the token endpoint and payload
+        mock_token_endpoint.return_value = "https://example.snowflakecomputing.com/"
+        mock_fmt_payload.return_value = "mocked_payload"
+
+        # Call the method
+        result = server.exchange_token()
+
+        # Verify the results
+        assert result == "token_data"
+        mock_http_server.assert_called_once_with(url="https://example.snowflakecomputing.com/")
+        mock_server_instance.request.assert_called_once_with(
+            method="POST",
+            path="/oauth/token",
+            body="mocked_payload",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+    @patch("rsconnect.api.HTTPServer")
+    @patch("rsconnect.api.SPCSConnectServer.token_endpoint")
+    @patch("rsconnect.api.SPCSConnectServer.fmt_payload")
+    def test_exchange_token_error_status(self, mock_fmt_payload, mock_token_endpoint, mock_http_server):
+        server = SPCSConnectServer("https://spcs.example.com", "example_connection")
+
+        # Mock the HTTP request with error status
+        mock_server_instance = mock_http_server.return_value
+        mock_response = Mock()
+        mock_response.status = 401
+        mock_response.full_uri = "https://example.snowflakecomputing.com/oauth/token"
+        mock_response.reason = "Unauthorized"
+        mock_server_instance.request.return_value = mock_response
+
+        # Mock the token endpoint and payload
+        mock_token_endpoint.return_value = "https://example.snowflakecomputing.com/"
+        mock_fmt_payload.return_value = "mocked_payload"
+
+        # Call the method and verify it raises the expected exception
+        with pytest.raises(RSConnectException, match="Failed to exchange Snowflake token"):
+            server.exchange_token()
+
+    @patch("rsconnect.api.HTTPServer")
+    @patch("rsconnect.api.SPCSConnectServer.token_endpoint")
+    @patch("rsconnect.api.SPCSConnectServer.fmt_payload")
+    def test_exchange_token_empty_response(self, mock_fmt_payload, mock_token_endpoint, mock_http_server):
+        server = SPCSConnectServer("https://spcs.example.com", "example_connection")
+
+        # Mock the HTTP request with empty response body
+        mock_server_instance = mock_http_server.return_value
+        mock_response = Mock()
+        mock_response.status = 200
+        mock_response.response_body = None
+        mock_server_instance.request.return_value = mock_response
+
+        # Mock the token endpoint and payload
+        mock_token_endpoint.return_value = "https://example.snowflakecomputing.com/"
+        mock_fmt_payload.return_value = "mocked_payload"
+
+        # Call the method and verify it raises the expected exception
+        with pytest.raises(
+            RSConnectException, match="Failed to exchange Snowflake token: Token exchange returned empty response"
+        ):
+            server.exchange_token()

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -1,0 +1,331 @@
+import json
+import logging
+import sys
+from subprocess import CalledProcessError
+from typing import List
+
+import pytest
+from pytest import LogCaptureFixture, MonkeyPatch
+
+from rsconnect.exception import RSConnectException
+from rsconnect.snowflake import (
+    ensure_snow_installed,
+    generate_jwt,
+    get_connection_parameters,
+    list_connections,
+)
+
+SAMPLE_CONNECTIONS = [
+    {
+        "connection_name": "dev",
+        "parameters": {
+            "account": "example-dev-acct",
+            "user": "alice@example.com",
+            "database": "EXAMPLE_DB",
+            "warehouse": "DEV_WH",
+            "role": "ACCOUNTADMIN",
+            "authenticator": "SNOWFLAKE_JWT",
+        },
+        "is_default": False,
+    },
+    {
+        "connection_name": "prod",
+        "parameters": {
+            "account": "example-prod-acct",
+            "user": "alice@example.com",
+            "database": "EXAMPLE_DB_PROD",
+            "schema": "DATA",
+            "warehouse": "DEFAULT_WH",
+            "role": "DEVELOPER",
+            "authenticator": "SNOWFLAKE_JWT",
+            "private_key_file": "/home/alice/snowflake/rsa_key.p8",
+        },
+        "is_default": True,
+    },
+]
+
+
+@pytest.fixture(autouse=True)
+def setup_caplog(caplog: LogCaptureFixture):
+    # Set the log level to debug to capture all logs
+    caplog.set_level(logging.DEBUG)
+
+
+def test_ensure_snow_installed_success(monkeypatch: MonkeyPatch):
+    # Test when snowflake-cli is installed - simpler approach
+    # Just check that the function doesn't raise an exception
+
+    # Let's directly mock snowflake.cli to simulate it being installed
+    # Create a fake module to return
+    class MockModule:
+        pass
+
+    # Create a fake snowflake module with a cli attribute
+    mock_snowflake = MockModule()
+    mock_snowflake.cli = MockModule()
+
+    # Add to sys.modules before test
+    sys.modules["snowflake"] = mock_snowflake
+    sys.modules["snowflake.cli"] = mock_snowflake.cli
+
+    try:
+        # Should not raise an exception
+        ensure_snow_installed()
+        # If we get here, test passes
+        assert True
+    finally:
+        # Clean up
+        if "snowflake" in sys.modules:
+            del sys.modules["snowflake"]
+        if "snowflake.cli" in sys.modules:
+            del sys.modules["snowflake.cli"]
+
+
+class MockRunResult:
+    def __init__(self, returncode: int = 0):
+        self.returncode = returncode
+
+
+def test_ensure_snow_installed_binary(monkeypatch: MonkeyPatch, caplog: LogCaptureFixture):
+    # Test when import fails but snow binary is available
+
+    monkeypatch.setattr("builtins.__import__", mock_failed_import)
+
+    # Mock run to return success
+    def mock_run(cmd: List[str], **kwargs):
+        assert cmd == ["snow", "--version"]
+        assert kwargs.get("capture_output") is True
+        assert kwargs.get("check") is True
+        return MockRunResult(returncode=0)
+
+    monkeypatch.setattr("rsconnect.snowflake.run", mock_run)
+
+    # Should not raise exception
+    ensure_snow_installed()
+
+    # Verify log message
+    assert "snowflake-cli is not installed" in caplog.text
+
+
+def test_ensure_snow_installed_nobinary(monkeypatch: MonkeyPatch, caplog: LogCaptureFixture):
+    # Test when import fails and snow binary is not found
+
+    # Remove snowflake modules if they exist
+    monkeypatch.delitem(sys.modules, "snowflake.cli", raising=False)
+    monkeypatch.delitem(sys.modules, "snowflake", raising=False)
+
+    monkeypatch.setattr("builtins.__import__", mock_failed_import)
+
+    # Mock run to raise FileNotFoundError
+    def mock_run(cmd: List[str], **kwargs):
+        if cmd == ["snow", "--version"]:
+            raise FileNotFoundError("No such file or directory: 'snow'")
+        return MockRunResult(returncode=0)
+
+    monkeypatch.setattr("rsconnect.snowflake.run", mock_run)
+
+    with pytest.raises(RSConnectException) as excinfo:
+        ensure_snow_installed()
+
+    assert "snow cannot be found" in str(excinfo.value)
+
+    # Verify log message
+    assert "snowflake-cli is not installed" in caplog.text
+
+
+def test_ensure_snow_installed_failing_binary(monkeypatch: MonkeyPatch, caplog: LogCaptureFixture):
+    # Test when import fails and snow binary exits with error
+
+    # Remove snowflake modules if they exist
+    monkeypatch.delitem(sys.modules, "snowflake.cli", raising=False)
+    monkeypatch.delitem(sys.modules, "snowflake", raising=False)
+
+    monkeypatch.setattr("builtins.__import__", mock_failed_import)
+
+    # Mock run to raise CalledProcessError
+    def mock_run(cmd: List[str], **kwargs):
+        if cmd == ["snow", "--version"]:
+            raise CalledProcessError(returncode=1, cmd=cmd, output="", stderr="Command failed with exit code 1")
+        return MockRunResult(returncode=0)
+
+    monkeypatch.setattr("rsconnect.snowflake.run", mock_run)
+
+    with pytest.raises(RSConnectException) as excinfo:
+        ensure_snow_installed()
+
+    assert "snow is installed but could not be run" in str(excinfo.value)
+
+    # Verify log message
+    assert "snowflake-cli is not installed" in caplog.text
+
+
+# Patch the import to raise ImportError
+original_import = __import__
+
+
+def mock_failed_import(name: str, *args, **kwargs):
+    if name.startswith("snowflake"):
+        raise ImportError(f"No module named '{name}'")
+    return original_import(name, *args, **kwargs)
+
+
+def test_list_connections(monkeypatch: MonkeyPatch):
+
+    class MockCompletedProcess:
+        returncode = 0
+        stdout = json.dumps(SAMPLE_CONNECTIONS)
+
+    def mock_snow(*args):
+        assert args == ("connection", "list", "--format", "json")
+        return MockCompletedProcess()
+
+    monkeypatch.setattr("rsconnect.snowflake.snow", mock_snow)
+
+    connections = list_connections()
+
+    assert len(connections) == 2
+    assert connections[1]["is_default"] is True
+
+
+def test_get_connection_noname_default(monkeypatch: MonkeyPatch):
+    # Test that get_connection_parameters() returns parameters from
+    # the default connection when no name is provided
+
+    monkeypatch.setattr("rsconnect.snowflake.list_connections", lambda: SAMPLE_CONNECTIONS)
+    monkeypatch.setattr("rsconnect.snowflake.ensure_snow_installed", lambda: None)
+
+    connection = get_connection_parameters()
+
+    assert connection["account"] == "example-prod-acct"
+    assert connection["role"] == "DEVELOPER"
+
+
+def test_get_connection_named(monkeypatch: MonkeyPatch):
+    # Test that get_connection_parameters() returns the specified connection when a name is provided
+
+    monkeypatch.setattr("rsconnect.snowflake.list_connections", lambda: SAMPLE_CONNECTIONS)
+    monkeypatch.setattr("rsconnect.snowflake.ensure_snow_installed", lambda: None)
+
+    connection = get_connection_parameters("dev")
+
+    # Should return the connection with the specified name
+    assert connection["account"] == "example-dev-acct"
+    assert connection["role"] == "ACCOUNTADMIN"
+
+
+def test_get_connection_errs_if_none(monkeypatch: MonkeyPatch):
+    # Test that get_connection_parameters() raises an exception when no matching connection is found
+
+    # Test with empty connections list
+    monkeypatch.setattr("rsconnect.snowflake.list_connections", lambda: [])
+    monkeypatch.setattr("rsconnect.snowflake.ensure_snow_installed", lambda: None)
+
+    with pytest.raises(RSConnectException) as excinfo:
+        get_connection_parameters()
+    assert "No Snowflake connections found" in str(excinfo.value)
+
+    # Test with connections but non-existent name
+    monkeypatch.setattr("rsconnect.snowflake.list_connections", lambda: SAMPLE_CONNECTIONS)
+
+    with pytest.raises(RSConnectException) as excinfo:
+        get_connection_parameters("nexiste")
+    assert "No Snowflake connection found with name 'nexiste'" in str(excinfo.value)
+
+
+def test_generate_jwt(monkeypatch: MonkeyPatch):
+    """Test the JWT generation for Snowflake connections."""
+    # Mock the generate_jwt subprocess call
+    sample_jwt = '{"message": "header.payload.signature"}'
+
+    class MockSnowGenerateJWT:
+        returncode = 0
+        stdout = sample_jwt
+
+    def mock_snow(*args):
+        assert args[0:3] == ("connection", "generate-jwt", "--connection")
+
+        # Check which connection we're generating a JWT for
+        conn_name = args[3]
+
+        # Empty string means default connection
+        if conn_name == "":
+            return MockSnowGenerateJWT()
+        elif conn_name == "dev":
+            return MockSnowGenerateJWT()
+        elif conn_name == "prod":
+            return MockSnowGenerateJWT()
+        else:
+            raise CalledProcessError(
+                returncode=1,
+                cmd=["snow"] + list(args),
+                output="",
+                stderr=f"Error: No connection found with name '{conn_name}'",
+            )
+
+    monkeypatch.setattr("rsconnect.snowflake.snow", mock_snow)
+    monkeypatch.setattr("rsconnect.snowflake.list_connections", lambda: SAMPLE_CONNECTIONS)
+
+    # Case 1: Test with default connection (no name parameter)
+    jwt = generate_jwt()
+    assert jwt == "header.payload.signature"
+
+    # Case 2: Test with a valid connection name
+    jwt = generate_jwt("dev")
+    assert jwt == "header.payload.signature"
+
+    # Case 3: Test with an invalid connection name
+    with pytest.raises(RSConnectException) as excinfo:
+        generate_jwt("nexiste")
+    assert "No Snowflake connection found with name 'nexiste'" in str(excinfo.value)
+
+
+def test_generate_jwt_command_failure(monkeypatch: MonkeyPatch):
+    """Test error handling when snow command fails."""
+
+    def mock_snow(*args):
+        raise CalledProcessError(
+            returncode=1, cmd=["snow"] + list(args), output="", stderr="Error: Authentication failed"
+        )
+
+    monkeypatch.setattr("rsconnect.snowflake.snow", mock_snow)
+    monkeypatch.setattr("rsconnect.snowflake.get_connection_parameters", lambda name=None: {})
+
+    with pytest.raises(RSConnectException) as excinfo:
+        generate_jwt()
+    assert "Failed to generate JWT" in str(excinfo.value)
+
+
+def test_generate_jwt_invalid_json(monkeypatch: MonkeyPatch):
+    """Test handling of invalid JSON output."""
+
+    class MockProcessInvalidJSON:
+        returncode = 0
+        stdout = "Not a JSON string"
+
+    def mock_snow(*args):
+        return MockProcessInvalidJSON()
+
+    monkeypatch.setattr("rsconnect.snowflake.snow", mock_snow)
+    monkeypatch.setattr("rsconnect.snowflake.get_connection_parameters", lambda name=None: {})
+
+    with pytest.raises(RSConnectException) as excinfo:
+        generate_jwt()
+    assert "Failed to parse JSON" in str(excinfo.value)
+
+
+def test_generate_jwt_missing_message(monkeypatch: MonkeyPatch):
+    """Test handling of JSON without the expected message field."""
+
+    class MockProcessNoMessage:
+        returncode = 0
+        stdout = '{"status": "success", "data": {}}'
+
+    def mock_snow(*args):
+        return MockProcessNoMessage()
+
+    monkeypatch.setattr("rsconnect.snowflake.snow", mock_snow)
+    monkeypatch.setattr("rsconnect.snowflake.get_connection_parameters", lambda name=None: {})
+
+    with pytest.raises(RSConnectException) as excinfo:
+        generate_jwt()
+    assert "Failed to generate JWT" in str(excinfo.value)


### PR DESCRIPTION
add support for deployments and administrative actions for  Connect in SPCS

## Type of Change

- [ ] Bug Fix           <!-- A change which fixes an existing issue --> 
- [x] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

- Take optional dependency on snowflake-cli
- Add support for passing a snowflake connection name to all commands that interact with Connect, and for storing a server nickname that is snowflake aware

## Automated Tests

Added new tests covering new API class and snowflake-cli

## Directions for Reviewers

One shot:

```
uvx --from git+https://github.com/posit-dev/rsconnect-python@spcs rsconnect deploy shiny my-shiny-app --server <SPCS-SERVER-ADDDRESS> --snowflake-connection-name <CONNECTION-NAME>
```

Realistic:

```
python -m pip install "git+https://github.com/posit-dev/rsconnect-python@spcs[snowflake]"
rsconnect add --server <SPCS-SERVER-ADDRESS> --snowflake-connection-name <CONNECTION-NAME> -n spcs
rsconnect details -n spcs
rsconnect deploy ...
```


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
