### PR TITLE
Adapt .python-version requirements to connect accepted ones

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,4 +24,7 @@
         "build/**": true,
         "venv/**": true,
     },
+    "python.analysis.exclude": [
+        "tests"
+    ],
 }

--- a/rsconnect/pyproject.py
+++ b/rsconnect/pyproject.py
@@ -134,9 +134,7 @@ def adapt_python_requires(
         for constraint in constraints:
             constraint = constraint.strip()
             if "@" in constraint or "-" in constraint or "/" in constraint:
-                raise InvalidVersionConstraintError(
-                    f"python specific implementations are not supported: {constraint}"
-                )
+                raise InvalidVersionConstraintError(f"python specific implementations are not supported: {constraint}")
 
             if "b" in constraint or "rc" in constraint or "a" in constraint:
                 raise InvalidVersionConstraintError(f"pre-release versions are not supported: {constraint}")

--- a/rsconnect/pyproject.py
+++ b/rsconnect/pyproject.py
@@ -122,7 +122,7 @@ def adapt_python_requires(
     """
     current_contraints = python_requires.split(",")
 
-    def _adapt_contraint(constraints: list[str]) -> typing.Generator[str, None, None]:
+    def _adapt_contraint(constraints: typing.List[str]) -> typing.Generator[str, None, None]:
         for constraint in constraints:
             constraint = constraint.strip()
             if "@" in constraint or "-" in constraint or "/" in constraint:

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -143,12 +143,12 @@ class TestPythonVersionRequirements:
     def test_python_version(self):
         env = Environment.create_python_environment(os.path.join(TESTDATA, "python-project", "using_pyversion"))
         assert env.python_interpreter == sys.executable
-        assert env.python_version_requirement == ">=3.8, <3.12"
+        assert env.python_version_requirement == ">=3.8,<3.12"
 
     def test_all_of_them(self):
         env = Environment.create_python_environment(os.path.join(TESTDATA, "python-project", "allofthem"))
         assert env.python_interpreter == sys.executable
-        assert env.python_version_requirement == ">=3.8, <3.12"
+        assert env.python_version_requirement == ">=3.8,<3.12"
 
     def test_missing(self):
         env = Environment.create_python_environment(os.path.join(TESTDATA, "python-project", "empty"))

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -11,7 +11,7 @@ from rsconnect.pyproject import (
     parse_pyproject_python_requires,
     parse_pyversion_python_requires,
     parse_setupcfg_python_requires,
-    InvalidVersionConstraintError
+    InvalidVersionConstraintError,
 )
 
 HERE = os.path.dirname(__file__)

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -170,6 +170,8 @@ def test_detect_python_version_requirement():
             "/usr/bin/python3.8",
             ValueError("Invalid python version, python specific implementations are not supported: /usr/bin/python3.8"),
         ),
+        (">=3.8,<3.10", ">=3.8,<3.10"),
+        (">=3.8, <*", ValueError("Invalid python version: <*")),
     ],
 )
 def test_python_version_file_adapt(content, expected):


### PR DESCRIPTION
## Intent

Connect requires a version constraint operator to always be specified, so version requirements like "3.8" are not valid, they need to e "~=3.8" to reproduce the intended behaviour.

fixes #659 

## Type of Change

- [x] Bug Fix           <!-- A change which fixes an existing issue --> 
- [ ] New Feature       <!-- A change which adds additional functionality -->
- [ ] Breaking Change   <!-- A breaking change which causes existing functionality to change -->

## Approach

Versions loaded from `.python-version` are validated against what connect supports and adapted when necessary

## Automated Tests

Added a dedicated test for version adapting

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you need clarification on any of these, feel free to ask. We're here to help! -->
- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.
- [ ] I have updated all related GitHub issues to reflect their current state.
