### PR TITLE
Mimic major-minor Connect behavior

### DIFF
--- a/rsconnect/pyproject.py
+++ b/rsconnect/pyproject.py
@@ -151,7 +151,7 @@ def adapt_python_requires(
                 else:
                     # only major specified “3” → ~=3.0 → >=3.0,<4.0
                     # major and minor specified “3.8” or “3.8.11” → ~=3.8.0 → >=3.8.0,<3.9.0
-                    constraint = '.'.join(constraint.split(".")[:2] + ["0"])
+                    constraint = ".".join(constraint.split(".")[:2] + ["0"])
                     yield f"~={constraint}"
 
     return ",".join(_adapt_contraint(current_contraints))

--- a/rsconnect/pyproject.py
+++ b/rsconnect/pyproject.py
@@ -149,7 +149,10 @@ def adapt_python_requires(
                 if "*" in constraint:
                     yield f"=={constraint}"
                 else:
-                    yield f"~={constraint.rstrip('0').rstrip('.')}"  # Remove trailing zeros and dots
+                    # only major specified “3” → ~=3.0 → >=3.0,<4.0
+                    # major and minor specified “3.8” or “3.8.11” → ~=3.8.0 → >=3.8.0,<3.9.0
+                    constraint = '.'.join(constraint.split(".")[:2] + ["0"])
+                    yield f"~={constraint}"
 
     return ",".join(_adapt_contraint(current_contraints))
 

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -149,8 +149,10 @@ def test_detect_python_version_requirement():
 @pytest.mark.parametrize(  # type: ignore
     ["content", "expected"],
     [
-        ("3.8", "~=3.8"),
-        ("3.8.0", "~=3.8"),
+        ("3", "~=3.0"),
+        ("3.8", "~=3.8.0"),
+        ("3.8.0", "~=3.8.0"),
+        ("3.8.11", "~=3.8.0"),
         ("3.8.0b1", InvalidVersionConstraintError("pre-release versions are not supported: 3.8.0b1")),
         ("3.8.0rc1", InvalidVersionConstraintError("pre-release versions are not supported: 3.8.0rc1")),
         ("3.8.0a1", InvalidVersionConstraintError("pre-release versions are not supported: 3.8.0a1")),


### PR DESCRIPTION
## Intent

Adapt all version numbers that don't have a constraint to a compatible constraint that accepts any patch release.

## Type of Change

- - [x] New Feature <!-- A change which adds additional functionality -->

## Approach

Change `adapt_python_requires` function in charge of performing the correct padding of version number and applying the compatible operator.

## User Impact

Mimics the major-minor current behaviour of connect

## Automated Tests

Tested by the `test_python_version_file_adapt` test.

## Checklist

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.

As far as I can see the current CHANGELOG still applies
