### PR TITLE
publish to PyPI as `rsconnect` and `rsconnect-python`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,9 @@ jobs:
 
   distributions:
     needs: test
+    strategy:
+      matrix:
+        package_name: ["rsconnect_python", "rsconnect"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -78,14 +81,19 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: 3.8.x
+    - name: Install uv # see scripts/temporary-rename
+      uses: astral-sh/setup-uv@v6
     - run: pip install -e '.[test]'
     - run: pip freeze
     - run: make dist
       id: create_dist
+      env:
+        PACKAGE_NAME: ${{ matrix.package_name }}
     - uses: actions/upload-artifact@v4
       with:
         name: distributions
         path: dist/
+      if: matrix.package_name == 'rsconnect_python'
     - run: pip install -vvv ${{ steps.create_dist.outputs.whl }}
     - run: rsconnect version
     - run: rsconnect --help
@@ -101,16 +109,19 @@ jobs:
       with:
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         aws-region: ${{ secrets.AWS_REGION }}
-    - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    - if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.package_name == 'rsconnect_python'
       run: make sync-latest-to-s3
-    - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      env:
+        BDIST_WHEEL: ${{ steps.create_dist.outputs.whl }}
+    - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && matrix.package_name == 'rsconnect_python'
       run: make sync-to-s3
+      env:
+        BDIST_WHEEL: ${{ steps.create_dist.outputs.whl }}
     - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}
-
   docs:
     needs: test
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ VERSION := $(shell python -m setuptools_scm)
 HOSTNAME := $(shell hostname)
 S3_PREFIX := s3://rstudio-connect-downloads/connect/rsconnect-python
 
-BDIST_WHEEL := dist/rsconnect_python-$(VERSION)-py2.py3-none-any.whl
+PACKAGE_NAME ?= rsconnect_python
+BDIST_WHEEL := dist/$(PACKAGE_NAME)-$(VERSION)-py2.py3-none-any.whl
 
 RUNNER = docker run \
   -it --rm \
@@ -75,11 +76,12 @@ clean:
 		./build \
 		./dist \
 		./htmlcov \
-		./rsconnect_python.egg-info
+		./rsconnect_python.egg-info \
+		./rsconnect.egg-info
 
 .PHONY: clean-stores
 clean-stores:
-	@find . -name "rsconnect-python" | xargs rm -rf
+	@find . -name "rsconnect-python" -o -name "rsconnect_python-*" -o -name "rsconnect-*" | xargs rm -rf
 
 .PHONY: shell
 shell: RUNNER = bash -c
@@ -126,6 +128,7 @@ version:
 # exported as a point of reference instead.
 .PHONY: dist
 dist:
+	./scripts/temporary-rename
 	pip wheel --no-deps -w dist .
 	twine check $(BDIST_WHEEL)
 	rm -vf dist/*.egg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "rsconnect_python"
-description = "Python integration with Posit Connect"
+description = "The Posit Connect command-line interface."
 
-authors = [{ name = "Michael Marchetti", email = "mike@posit.co" }]
+authors = [{ name = "Posit, PBC", email = "rsconnect@posit.co" }]
 license = { file = "LICENSE.md" }
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.8"
@@ -84,6 +84,10 @@ packages = ["rsconnect"]
 
 [tool.setuptools_scm]
 write_to = "rsconnect/version.py"
+# since we dirty the state by transforming the file
+# keep the version number consistent
+version_scheme = "no-guess-dev"
+local_scheme = "no-local-version"
 
 [tool.setuptools.package-data]
 rsconnect = ["py.typed"]

--- a/scripts/temporary-rename
+++ b/scripts/temporary-rename
@@ -1,0 +1,18 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# dependencies = ["toml"]
+# ///
+import os
+
+import toml
+
+if "PACKAGE_NAME" in os.environ:
+
+    with open("pyproject.toml", "r") as f:
+        pyproject = toml.load(f)
+
+    # Override package name from pyproject.toml with environment variable
+    pyproject["project"]["name"] = os.environ["PACKAGE_NAME"]
+
+    with open("pyproject.toml", "w") as f:
+        toml.dump(pyproject, f)


### PR DESCRIPTION
- update makefile to support building wheels with a different package name
- add a script to rewrite the package name in CI
  - `uv run` is used for this so that the necessary `toml` dependency
    is installed without drama
