### PR TITLE
use trusted publishing flow rather than pypi token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,9 +119,7 @@ jobs:
         BDIST_WHEEL: ${{ steps.create_dist.outputs.whl }}
     - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_TOKEN }}
+
   docs:
     needs: test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Following the directions here: https://docs.pypi.org/trusted-publishers/using-a-publisher/

- Publishing from `main.yml` has been set in PyPI
- the workflow has `id-token: write` permissions

removing the token means the workflow will obtain the needed oidc token at publish time.
