### PR TITLE
Output the preview url in case of drafts

### DIFF
--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -570,6 +570,9 @@ class RSConnectClient(HTTPServer):
 
         task = self.content_deploy(app_guid, app_bundle["id"], activate=activate)
 
+        # http://ADDRESS/preview/APP_GUID/BUNDLE_ID
+        # Using replace makes this a bit more robust to changes in the URL structure
+        # like connect being served on a subpath.
         preview_url = app["url"].replace("/content/", "/preview/") + f"/{app_bundle['id']}"
 
         return {

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -335,6 +335,7 @@ class RSConnectClientDeployResult(TypedDict):
     app_id: str
     app_guid: str
     app_url: str
+    preview_url: str
     title: str | None
 
 
@@ -569,11 +570,14 @@ class RSConnectClient(HTTPServer):
 
         task = self.content_deploy(app_guid, app_bundle["id"], activate=activate)
 
+        preview_url = app["url"].replace("/content/", "/preview/") + f"/{app_bundle['id']}"
+
         return {
-            "task_id": task["task_id"],
+            "task_id": task["id"],
             "app_id": app_id,
             "app_guid": app["guid"],
             "app_url": app["url"],
+            "preview_url": preview_url,
             "title": app["title"],
         }
 

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -46,9 +46,9 @@ else:
 # they should both come from the same typing module.
 # https://peps.python.org/pep-0655/#usage-in-python-3-11
 if sys.version_info >= (3, 11):
-    from typing import NotRequired, TypedDict
+    from typing import TypedDict
 else:
-    from typing_extensions import NotRequired, TypedDict
+    from typing_extensions import TypedDict
 
 from . import validation
 from .bundle import _default_title

--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -1136,7 +1136,9 @@ class RSConnectExecutor:
             app_dashboard_url = app_config.get("config_url")
             log_callback.info("Deployment completed successfully.")
             log_callback.info("\t Dashboard content URL: %s", app_dashboard_url)
-            log_callback.info("\t Direct content URL: %s", self.deployed_info["preview_url"] or self.deployed_info["app_url"])
+            log_callback.info(
+                "\t Direct content URL: %s", self.deployed_info["preview_url"] or self.deployed_info["app_url"]
+            )
 
         return self
 

--- a/rsconnect/http_support.py
+++ b/rsconnect/http_support.py
@@ -405,7 +405,15 @@ class HTTPServer(object):
                     for key, value in response.getheaders():
                         logger.debug("--> %s: %s" % (key, value))
                     logger.debug("Body:")
-                    logger.debug("--> %s" % response_body)
+                    if response.getheader("Content-Type", "").startswith("application/json"):
+                        # Only print JSON responses.
+                        # Otherwise we end up dumping entire web pages to the log.
+                        try:
+                            logger.debug("--> %s" % response_body)
+                        except json.JSONDecodeError:
+                            logger.debug("--> <invalid JSON>")
+                    else:
+                        logger.debug("--> <non-json-response>")
             finally:
                 if local_connection:
                     self.__exit__()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -241,7 +241,9 @@ class TestMain:
                 # Do not validate app mode, so that the "target" content doesn't matter.
                 "rsconnect.api.RSConnectExecutor.validate_app_mode",
                 new=lambda self_, *args, **kwargs: self_,
-            ), caplog.at_level("INFO"):
+            ), caplog.at_level(
+                "INFO"
+            ):
                 result = runner.invoke(cli, args)
             assert result.exit_code == 0, result.output
             assert deploy_api_invoked == [True]
@@ -249,7 +251,9 @@ class TestMain:
             if expected_activate:
                 assert "Direct content URL: http://fake_server/content/1234-5678-9012-3456" in caplog.text
             else:
-                assert "Direct content URL: http://fake_server/preview/1234-5678-9012-3456/FAKE_BUNDLE_ID" in caplog.text
+                assert (
+                    "Direct content URL: http://fake_server/preview/1234-5678-9012-3456/FAKE_BUNDLE_ID" in caplog.text
+                )
         finally:
             if original_api_key_value:
                 os.environ["CONNECT_API_KEY"] = original_api_key_value

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -146,7 +146,7 @@ class TestMain:
                     "id": "1234-5678-9012-3456",
                     "guid": "1234-5678-9012-3456",
                     "title": "app5",
-                    "url": "http://fake_server/apps/1234-5678-9012-3456",
+                    "url": "http://fake_server/content/1234-5678-9012-3456",
                 }
             ),
             adding_headers={"Content-Type": "application/json"},
@@ -247,7 +247,7 @@ class TestMain:
             assert deploy_api_invoked == [True]
             assert "Deployment completed successfully." in caplog.text
             if expected_activate:
-                assert "Direct content URL: http://fake_server/apps/1234-5678-9012-3456" in caplog.text
+                assert "Direct content URL: http://fake_server/content/1234-5678-9012-3456" in caplog.text
             else:
                 assert "Direct content URL: http://fake_server/preview/1234-5678-9012-3456/FAKE_BUNDLE_ID" in caplog.text
         finally:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -113,7 +113,7 @@ class TestMain:
         ],
     )
     @httpretty.activate(verbose=True, allow_net_connect=False)
-    def test_deploy_draft(self, command, target, expected_activate):
+    def test_deploy_draft(self, command, target, expected_activate, caplog):
         original_api_key_value = os.environ.pop("CONNECT_API_KEY", None)
         original_server_value = os.environ.pop("CONNECT_SERVER", None)
 
@@ -241,10 +241,15 @@ class TestMain:
                 # Do not validate app mode, so that the "target" content doesn't matter.
                 "rsconnect.api.RSConnectExecutor.validate_app_mode",
                 new=lambda self_, *args, **kwargs: self_,
-            ):
+            ), caplog.at_level("INFO"):
                 result = runner.invoke(cli, args)
             assert result.exit_code == 0, result.output
             assert deploy_api_invoked == [True]
+            assert "Deployment completed successfully." in caplog.text
+            if expected_activate:
+                assert "Direct content URL: http://fake_server/apps/1234-5678-9012-3456" in caplog.text
+            else:
+                assert "Direct content URL: http://fake_server/preview/1234-5678-9012-3456/FAKE_BUNDLE_ID" in caplog.text
         finally:
             if original_api_key_value:
                 os.environ["CONNECT_API_KEY"] = original_api_key_value


### PR DESCRIPTION
When drafts are available, we need to tell the users where to see the launched content.

## Intent

Always oputput as "Direct URL" the url where the currently deployed content is visible.
When it's an active application we show the application url, when it's a draft we output the draft url.

## Type of Change

- [x] New Feature       <!-- A change which adds additional functionality -->

## Approach

Expand `RSConnectClientDeployResult` with a new "preview_url" field which has the url where the deployed bundle is served. If the bundle was activated, we will set this to `None` as the content is visibile on the `app_url`, if the bundle wasn't activate instead we set this so that it can be printed to user.

## Automated Tests

`test_deploy_draft` test now also tests for the right URL to be printed

## Directions for Reviewers

~This depends on #679~

## Checklist

- [x] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes.

I think we can avoid updating the CHANGELOG further as #679 already added the concept of deploying drafts as a new feature.
