### PR TITLE
Improve clarity for user when deploying a draft

### DIFF
--- a/rsconnect/api.py
+++ b/rsconnect/api.py
@@ -573,7 +573,7 @@ class RSConnectClient(HTTPServer):
         # http://ADDRESS/preview/APP_GUID/BUNDLE_ID
         # Using replace makes this a bit more robust to changes in the URL structure
         # like connect being served on a subpath.
-        preview_url = app["url"].replace("/content/", "/preview/") + f"/{app_bundle['id']}"
+        preview_url = app["url"].replace("/content/", "/preview/").rstrip("/") + f"/{app_bundle['id']}"
 
         return {
             "task_id": task["task_id"],
@@ -1131,14 +1131,16 @@ class RSConnectExecutor:
                 raise_on_error,
             )
             log_lines = self.remote_server.handle_bad_response(log_lines)
-            app_config = self.client.app_config(self.deployed_info["app_id"])
-            app_config = self.remote_server.handle_bad_response(app_config)
-            app_dashboard_url = app_config.get("config_url")
+
             log_callback.info("Deployment completed successfully.")
-            log_callback.info("\t Dashboard content URL: %s", app_dashboard_url)
-            log_callback.info(
-                "\t Direct content URL: %s", self.deployed_info["preview_url"] or self.deployed_info["app_url"]
-            )
+            if self.deployed_info.get("preview_url"):
+                log_callback.info("\t Preview content URL: %s", self.deployed_info["preview_url"])
+            else:
+                app_config = self.client.app_config(self.deployed_info["app_id"])
+                app_config = self.remote_server.handle_bad_response(app_config)
+                app_dashboard_url = app_config.get("config_url")
+                log_callback.info("\t Dashboard content URL: %s", app_dashboard_url)
+                log_callback.info("\t Direct content URL: %s", self.deployed_info["app_url"])
 
         return self
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -252,7 +252,7 @@ class TestMain:
                 assert "Direct content URL: http://fake_server/content/1234-5678-9012-3456" in caplog.text
             else:
                 assert (
-                    "Direct content URL: http://fake_server/preview/1234-5678-9012-3456/FAKE_BUNDLE_ID" in caplog.text
+                    "Preview content URL: http://fake_server/preview/1234-5678-9012-3456/FAKE_BUNDLE_ID" in caplog.text
                 )
         finally:
             if original_api_key_value:


### PR DESCRIPTION
Emitting both "Dashboard URL" and "Direct content URL" in case of drafts could be confusing for the user, as accessing the "Dashboard URL" will show the _wrong_ content.

## Intent

Improve clarity by clearly emitting a "Preview content URL" when a draft is deployed.

Normal Deploy:

```
Deployment completed successfully.
	 Dashboard content URL: https://SERVER/connect/#/apps/6d5bfc35-e596-40bc-a039-97cd926ea7ab/access
	 Direct content URL: https://SERVER/content/6d5bfc35-e596-40bc-a039-97cd926ea7ab/
```

Draft Deploy:

```
Deployment completed successfully.
	 Preview content URL: https://SERVER/preview/6d5bfc35-e596-40bc-a039-97cd926ea7ab/278869
```

## Type of Change

- [x] Tweak

## Approach

When `--draft` is used we don't output the "Dashboard URL" anymore

## Automated Tests

The existing `test_deploy_draft` test has been updated to verify the output.


