### PR TITLE
Update system caches tests

### DIFF
--- a/tests/test_main_system_caches.py
+++ b/tests/test_main_system_caches.py
@@ -10,10 +10,10 @@ from rsconnect.main import cli
 CONNECT_SERVER = "http://localhost:3939"
 CONNECT_KEYS_JSON = "vetiver-testing/rsconnect_api_keys.json"
 
-ADD_CACHE_COMMAND = "docker compose exec -u rstudio-connect -T rsconnect mkdir -p /data/python-environments/pip/1.2.3"
-RM_CACHE_COMMAND = "docker compose exec -u rstudio-connect -T rsconnect rm -Rf /data/python-environments/pip/1.2.3"
+ADD_CACHE_COMMAND = "docker compose exec -u rstudio-connect -T rsconnect mkdir -p /data/python-environments/_packages_cache/pip/1.2.3"
+RM_CACHE_COMMAND = "docker compose exec -u rstudio-connect -T rsconnect rm -Rf /data/python-environments/_packages_cache/pip/1.2.3"
 # The following returns int(0) if dir exists, else int(256).
-CACHE_EXISTS_COMMAND = "docker compose exec -u rstudio-connect -T rsconnect [ -d /data/python-environments/pip/1.2.3 ]"
+CACHE_EXISTS_COMMAND = "docker compose exec -u rstudio-connect -T rsconnect [ -d /data/python-environments/_packages_cache/pip/1.2.3 ]"
 SERVICE_RUNNING_COMMAND = "docker compose ps --services --filter 'status=running' | grep rsconnect"
 
 


### PR DESCRIPTION
 ## Intent

connect path to system caches has moved inside `python-environments/_packages_cache`, the test suite is still looking in the old path.

## Type of Change

- [x] Bug Fix           <!-- A change which fixes an existing issue --> 
