### PR TITLE
docs: make release changelog commands portable to macOS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,8 @@ before _EACH_ release, even beta releases.
 VERSION="$(uv version --bump stable --dry-run --short)"  # use "--bump minor" if there are new features
 git checkout -b "release-$VERSION" main
 uv version "$VERSION"
-sed -i "s/^## Unreleased/## [$VERSION] - $(date +%Y-%m-%d)/" docs/CHANGELOG.md
+# perl, not sed: GNU sed (Linux) and BSD sed (macOS) take different -i arguments
+perl -pi -e "s/^## Unreleased/## [$VERSION] - $(date +%Y-%m-%d)/" docs/CHANGELOG.md
 git commit -am "Release $VERSION"
 git push -u origin "release-$VERSION"
 gh pr create --title "Release $VERSION" --body "Release $VERSION"
@@ -129,7 +130,7 @@ version
 ```bash
 VERSION="$(uv version --bump patch --bump dev --dry-run --short)"  # e.g. 1.29.1 -> 1.29.2.dev1
 git checkout -b "rearm-$VERSION" main
-sed -i '0,/^## \[/s//## Unreleased\n\n&/' docs/CHANGELOG.md
+perl -0777 -pi -e 's/^## \[/## Unreleased\n\n$&/m' docs/CHANGELOG.md
 uv version "$VERSION"
 git commit -am "Begin $VERSION development"
 git push -u origin "rearm-$VERSION"


### PR DESCRIPTION
## Intent

The release and re-arm steps in CONTRIBUTING.md use `sed -i` in forms that only work with GNU sed. On macOS, the release step fails because BSD sed requires a suffix argument after `-i`, and the re-arm step has no BSD equivalent at all: it relies on the GNU-only `0,/re/` address range and on `\n` in the replacement text. Anyone releasing from a Mac has to translate the commands by hand.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change

## Approach

Replace both `sed -i` calls with perl, which is preinstalled on macOS and on mainstream Linux distributions and behaves the same on both:

- Release step: `perl -pi -e "s/^## Unreleased/## [$VERSION] - $(date +%Y-%m-%d)/" docs/CHANGELOG.md`
- Re-arm step: `perl -0777 -pi -e 's/^## \[/## Unreleased\n\n$&/m' docs/CHANGELOG.md`

The re-arm command slurps the file so `^` with the `/m` flag matches the start of each line, and without `/g` only the first `## [` heading gets the new `## Unreleased` section inserted above it.

A one-line comment above the first command explains why it is perl rather than sed, so the change is not reverted later.

Alternatives considered: `sed -i.bak` is portable for the release step but not the re-arm step; awk needs a temp file and a move; a `just` recipe backed by Python would be cleanest but is more than this doc fix needs.

## Automated Tests

None. This changes documentation only. Both commands were run by hand on macOS against a copy of `docs/CHANGELOG.md` and produced the expected result.

## Directions for Reviewers

On a Mac or Linux machine, copy `docs/CHANGELOG.md` somewhere scratch and run the two commands from the diff against it, with `VERSION` set to any value. The release command should rename `## Unreleased` to a dated heading. The re-arm command should insert a blank-line-separated `## Unreleased` section above the topmost release heading, once.

## Checklist

- [ ] I have updated [CHANGELOG.md](../CHANGELOG.md) to cover notable changes. (Not needed: contributor docs only, no user-facing change.)
- [x] I have updated all related GitHub issues to reflect their current state. (None.)
- [ ] I have run the `rsconnect-python-tests-at-night` workflow in Connect against this feature branch. (Not needed: no code change.)
